### PR TITLE
DESK-304. Update signin to handle cognito API failures and message user

### DIFF
--- a/frontend/src/models/auth.ts
+++ b/frontend/src/models/auth.ts
@@ -44,7 +44,7 @@ export default createModel({
         if (backendCredentials.username && backendCredentials.authHash) user = backendCredentials
         if (storedUser) user = JSON.parse(storedUser)
       }
-
+      console.log('USER', user)
       if (user) {
         dispatch.auth.checkSignInStarted()
         Controller.emit('authentication', { username: user.username, authHash: user.authHash })
@@ -72,23 +72,27 @@ export default createModel({
     async signIn({ password, username }) {
       dispatch.auth.signInStarted()
       console.log('Logging in user', username)
-
       let user
-      try {
-        user = await r3.user.login(username, password)
-      } catch (error) {
-        dispatch.auth.signInError(error.message)
-        return
-      }
-
-      if (!user) {
-        console.warn('Could not log in user:', { username })
-        dispatch.auth.signInError('User not found')
-        return
-      }
-
-      dispatch.auth.setUser(user)
-      Controller.open()
+      r3.post('/user/login', { username, password })
+        .then(resp => {
+          user = r3.user.process(resp, username)
+          r3.user.updateCredentials(user)
+          dispatch.auth.setUser(user)
+          Controller.open()
+        })
+        .catch(error => {
+          const e = error.response.data
+          if (e.code && ['SMS_MFA', 'SOFTWARE_TOKEN_MFA', 'MFA_SETUP'].includes(e.code)) {
+            dispatch.auth.signInError(
+              "This version of remote.it desktop doesn't support two-factor authentication. Please upgrade to the latest version or disable two-factor authentication in the web portal."
+            )
+          } else {
+            dispatch.auth.signInError(e.reason)
+          }
+          return
+        })
+      console.log(user)
+      return user
     },
     async signedIn() {
       await dispatch.auth.checkSession()

--- a/frontend/src/models/auth.ts
+++ b/frontend/src/models/auth.ts
@@ -44,7 +44,6 @@ export default createModel({
         if (backendCredentials.username && backendCredentials.authHash) user = backendCredentials
         if (storedUser) user = JSON.parse(storedUser)
       }
-      console.log('USER', user)
       if (user) {
         dispatch.auth.checkSignInStarted()
         Controller.emit('authentication', { username: user.username, authHash: user.authHash })
@@ -91,7 +90,6 @@ export default createModel({
           }
           return
         })
-      console.log(user)
       return user
     },
     async signedIn() {


### PR DESCRIPTION
User will need to upgrade the desktop app when cognito is rolled out. API v27 will not support cognito login with Google and will not support 2-FA.
The plan is to have a new version of the desktop available before enabling cognito which will use API v28 and handle all of the cases for cognito sign in.