### PR TITLE
[DESK-278] On load setup page also load the cli config values

### DIFF
--- a/backend/src/cliInterface.ts
+++ b/backend/src/cliInterface.ts
@@ -21,6 +21,7 @@ class CLIInterface extends CLI {
         }
         break
     }
+    this.read()
   }
 
   async handle(targets: ITarget[]) {

--- a/frontend/src/pages/SetupPage/SetupPage.tsx
+++ b/frontend/src/pages/SetupPage/SetupPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Container } from '../../components/Container'
 import { useDispatch, useSelector } from 'react-redux'
 import { ApplicationState, Dispatch } from '../../store'
@@ -29,6 +29,11 @@ export const SetupPage: React.FC = () => {
   const deleteDevice = () => {
     Controller.emit('device', 'DELETE')
   }
+
+  useEffect(() => {
+    // Refresh device data
+    Controller.emit('device')
+  }, [])
 
   return admin && user && user.username !== admin ? (
     <Container


### PR DESCRIPTION
### Description

Provide a way for the Desktop to pickup changes made by the cli in the UI.

### Checklist

- [x] Pull Request title is in the format `[PROJ-12345] Some useful description here...`
- [x] The git branch is in the format `PROJ-12345-some-useful-description-here`
- [x] I have added one or more reviewers
- [x] This PR only contains one isolated change (bug fix, feature, etc)
- [x] I have manually reviewed this PR to make sure only the files I intended to change were changed and nothing else
- [x] I have notified reviewers on Slack by @ mentioning them in the `#desktop`channel
- [x] I have moved the Jira ticket into `Resolved` state and made a note in the ticket with a link to this PR

### Test plan

Load Desktop.
Observe Hosted page state.
On the command line make a change to the hosted system setup.
ie `sudo remoteit setup`
In desktop navigate away and back to the Hosted page.
You should see the state updated based on the cli change.

### Ticket

https://remoteit.atlassian.net/browse/DESK-278
