### PR TITLE
[DESK-389] Stop system service on auto-update enter restart

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -10,6 +10,7 @@ import Tracker from './Tracker'
 import Logger from './Logger'
 import LAN from './LAN'
 import user from './User'
+import cli from './cliInterface'
 import { hostName } from './helpers/nameHelper'
 import { IP_PRIVATE } from './constants'
 import { WEB_DIR } from './constants'
@@ -47,4 +48,4 @@ export default new Application()
 
 // To support Electron wrapper
 export { EVENTS } from './electronInterface'
-export { ConnectionPool, environment, EventBus, hostName, IP_PRIVATE, LAN, Logger, user, WEB_DIR }
+export { ConnectionPool, environment, EventBus, hostName, IP_PRIVATE, LAN, Logger, user, cli, WEB_DIR }

--- a/src/AutoUpdater.ts
+++ b/src/AutoUpdater.ts
@@ -1,4 +1,5 @@
 import electron from 'electron'
+import { cli } from 'remoteit-headless'
 import { EventBus, Logger, EVENTS } from 'remoteit-headless'
 import { autoUpdater } from 'electron-updater'
 
@@ -28,7 +29,8 @@ export default class AppUpdater {
     }
   }
 
-  restart() {
+  async restart() {
+    await cli.stopService()
     autoUpdater.quitAndInstall()
     electron.app.quit()
   }


### PR DESCRIPTION
### Description

Prompt and stop system service before auto update restart. So that the old service can be killed before starting the new one on update. Especially because on windows the bin directory is removed.

### Checklist

<!-- Please make sure all the boxes below are checked or removed if not relevant -->

- [x] Pull Request title is in the format `[PROJ-12345] Some useful description here...`
- [ ] ~~I have prefixed this PR with `[WIP]` if it is a Work In Progress (not ready to merge)~~
- [x] The git branch is in the format `PROJ-12345-some-useful-description-here`
- [x] I have added one or more reviewers
- [ ] ~~I have added/updated tests for any code changes~~
- [ ] ~~I have updated documentation (including README, inline comments and docs.remote.it docs)~~
- [x] This PR only contains one isolated change (bug fix, feature, etc)
- [ ] ~~Translation strings added/updated for all user-visible text~~
- [x] I have manually reviewed this PR to make sure only the files I intended to change were changed and nothing else
- [x] I have notified reviewers on Slack by @ mentioning them in the `#desktop`channel
- [x] I have moved the Jira ticket into `Resolved` state and made a note in the ticket with a link to this PR

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

This must be tested when 2.5.22-alpha can be updated to another version. Or ask @JamieRuderman for a test build with this code tagged as an older version.

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/DESK-389>
