### PR TITLE
[DESK-408] deprecate appImage support

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,14 +83,6 @@
       "category": "Network",
       "target": [
         {
-          "target": "AppImage",
-          "arch": [
-            "armv7l",
-            "x64",
-            "arm64"
-          ]
-        },
-        {
           "target": "deb",
           "arch": [
             "armv7l",


### PR DESCRIPTION
### Description

I would also like to stop supporting the AppImage Linux build. They take extra time to build and a long time to upload to GitHub. As well they incur additional testing effort and time and they haven't been downloaded almost at all. The couple times I could chalk up to my own testing, so we haven’t really started supporting them. https://somsubhra.com/github-release-stats/?username=remoteit&repository=desktop

### Checklist

<!-- Please make sure all the boxes below are checked or removed if not relevant -->

- [x] Pull Request title is in the format `[PROJ-12345] Some useful description here...`
- [ ] ~~I have prefixed this PR with `[WIP]` if it is a Work In Progress (not ready to merge)~~
- [x] The git branch is in the format `PROJ-12345-some-useful-description-here`
- [x] I have added one or more reviewers
- [ ] ~~I have added/updated tests for any code changes~~
- [ ] ~~I have updated documentation (including README, inline comments and docs.remote.it docs)~~
- [x] This PR only contains one isolated change (bug fix, feature, etc)
- [ ] ~~Translation strings added/updated for all user-visible text~~
- [x] I have manually reviewed this PR to make sure only the files I intended to change were changed and nothing else
- [x] I have notified reviewers on Slack by @ mentioning them in the `#desktop`channel
- [x] I have moved the Jira ticket into `Resolved` state and made a note in the ticket with a link to this PR

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Build desktop
2. No appimage assets are created

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/DESK-408>
