### PR TITLE
[DESK-455] Remove service level status icons

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "semi": false,
   "singleQuote": true,
   "trailingComma": "es5",
-  "printWidth": 120
+  "printWidth": 120,
+  "arrowParens": "avoid"
 }

--- a/frontend/src/buttons/ConnectButton/ConnectButton.tsx
+++ b/frontend/src/buttons/ConnectButton/ConnectButton.tsx
@@ -27,7 +27,7 @@ export const ConnectButton: React.FC<ConnectButtonProps> = ({
     <Fade in={!hidden} timeout={600}>
       <div>
         <DynamicButton
-          title="Connect"
+          title={connecting ? 'Connecting ...' : 'Connect'}
           icon="exchange"
           loading={connecting}
           color={color}

--- a/frontend/src/buttons/DynamicButton/DynamicButton.tsx
+++ b/frontend/src/buttons/DynamicButton/DynamicButton.tsx
@@ -9,11 +9,21 @@ type Props = {
   color?: Color
   size?: 'icon' | 'medium' | 'small'
   disabled?: boolean
+  disabledColor?: Color
   loading?: boolean
   onClick: () => void
 }
 
-export const DynamicButton: React.FC<Props> = ({ title, icon, onClick, color, size = 'icon', disabled, loading }) => {
+export const DynamicButton: React.FC<Props> = ({
+  title,
+  icon,
+  onClick,
+  color,
+  size = 'icon',
+  disabled,
+  disabledColor = 'grayDark',
+  loading,
+}) => {
   let styles = {}
 
   const clickHandler = (event: React.MouseEvent) => {
@@ -23,7 +33,7 @@ export const DynamicButton: React.FC<Props> = ({ title, icon, onClick, color, si
   }
 
   if (loading) icon = 'spinner-third'
-  if (disabled) color = 'grayDark'
+  if (disabled) color = disabledColor
 
   const IconComponent = (
     <Icon

--- a/frontend/src/buttons/OfflineButton/OfflineButton.tsx
+++ b/frontend/src/buttons/OfflineButton/OfflineButton.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { IService } from 'remote.it'
+import { DynamicButton } from '../DynamicButton'
+import { Color } from '../../styling'
+import { Fade } from '@material-ui/core'
+
+type Props = {
+  service?: IService
+}
+
+export const OfflineButton: React.FC<Props> = ({ service }) => {
+  const hidden = service && service.state === 'active'
+  return (
+    <Fade in={!hidden} timeout={600}>
+      <div>
+        <DynamicButton
+          title="Offline"
+          disabledColor="grayLight"
+          disabled={true}
+          size="small"
+          icon="none"
+          onClick={() => {}}
+        />
+      </div>
+    </Fade>
+  )
+}

--- a/frontend/src/buttons/OfflineButton/index.ts
+++ b/frontend/src/buttons/OfflineButton/index.ts
@@ -1,0 +1,1 @@
+export { OfflineButton } from './OfflineButton'

--- a/frontend/src/components/ServiceListItem/ServiceListItem.tsx
+++ b/frontend/src/components/ServiceListItem/ServiceListItem.tsx
@@ -10,6 +10,7 @@ import { lanShareRestriction, lanShared } from '../../helpers/lanSharing'
 import { ConnectionErrorMessage } from '../ConnectionErrorMessage'
 import { ListItemLocation } from '../ListItemLocation'
 import { DisconnectButton } from '../../buttons/DisconnectButton'
+import { OfflineButton } from '../../buttons/OfflineButton'
 import { ConnectButton } from '../../buttons/ConnectButton'
 import { LaunchButton } from '../../buttons/LaunchButton'
 import { ErrorButton } from '../../buttons/ErrorButton'
@@ -48,12 +49,13 @@ export function ServiceListItem({ connection, service, indent }: ServiceListItem
     <>
       <ListItemLocation className={className} pathname={`${location.pathname}/${id}`} disabled={notOwner}>
         <div className={css.buttons}>
-          <ConnectButton connection={connection} service={service} size="small" color="success" />
-          <DisconnectButton connection={connection} size="small" color="primary" />
+          <ConnectButton connection={connection} service={service} size="small" />
+          <DisconnectButton connection={connection} size="small" />
+          <OfflineButton service={service} />
         </div>
-        <ListItemIcon>
+        {/* <ListItemIcon>
           <ConnectionStateIcon connection={connection} service={service} size="lg" />
-        </ListItemIcon>
+        </ListItemIcon> */}
         <ListItemText primary={<ServiceName service={service} connection={connection} />} secondary={details} />
         {connection && connection.active && <Throughput connection={connection} />}
         <ErrorButton
@@ -78,8 +80,10 @@ const useStyles = makeStyles({
   buttons: {
     width: 121,
     marginLeft: spacing.md,
+    marginRight: spacing.lg,
     position: 'relative',
-    '& > div:first-child': { position: 'absolute', width: '100%' },
+    '& > div': { position: 'absolute', width: '100%' },
+    '& > div:last-child': { position: 'relative' },
   },
   details: { '& > span': { marginLeft: spacing.xs } },
   restriction: { color: colors.grayDarker },

--- a/frontend/src/components/ServiceListItem/ServiceListItem.tsx
+++ b/frontend/src/components/ServiceListItem/ServiceListItem.tsx
@@ -4,8 +4,7 @@ import { useSelector } from 'react-redux'
 import { ApplicationState } from '../../store'
 import { hostName } from '../../helpers/nameHelper'
 import { useLocation } from 'react-router-dom'
-import { ConnectionStateIcon } from '../ConnectionStateIcon'
-import { ListItemIcon, ListItemText, ListItemSecondaryAction } from '@material-ui/core'
+import { ListItemText, ListItemSecondaryAction } from '@material-ui/core'
 import { lanShareRestriction, lanShared } from '../../helpers/lanSharing'
 import { ConnectionErrorMessage } from '../ConnectionErrorMessage'
 import { ListItemLocation } from '../ListItemLocation'
@@ -53,9 +52,6 @@ export function ServiceListItem({ connection, service, indent }: ServiceListItem
           <DisconnectButton connection={connection} size="small" />
           <OfflineButton service={service} />
         </div>
-        {/* <ListItemIcon>
-          <ConnectionStateIcon connection={connection} service={service} size="lg" />
-        </ListItemIcon> */}
         <ListItemText primary={<ServiceName service={service} connection={connection} />} secondary={details} />
         {connection && connection.active && <Throughput connection={connection} />}
         <ErrorButton

--- a/frontend/src/pages/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage/SettingsPage.tsx
@@ -65,17 +65,19 @@ export const SettingsPage = connect(
     return (
       <Container
         header={
-          <Typography className={css.header} variant="h1">
-            <Tooltip title="Visit remote.it on the web">
-              <ButtonBase onClick={() => window.open('https://remote.it')}>
-                <Logo width={110} />
-              </ButtonBase>
-            </Tooltip>
-          </Typography>
+          <>
+            <Typography className={css.header} variant="h1">
+              <Tooltip title="Visit remote.it on the web">
+                <ButtonBase onClick={() => window.open('https://remote.it')}>
+                  <Logo width={110} />
+                </ButtonBase>
+              </Tooltip>
+            </Typography>
+            <DeviceSetupItem />
+            <Divider />
+          </>
         }
       >
-        <DeviceSetupItem />
-        <Divider />
         <Typography variant="subtitle1">User</Typography>
         <List>
           <SettingsListItem
@@ -87,7 +89,7 @@ export const SettingsPage = connect(
           />
           <SettingsListItem
             label="Sign out"
-            subLabel={`Signed is as ${user && user.username}`}
+            subLabel={`Signed in as ${user && user.username}`}
             icon="sign-out"
             onClick={signOutWarning}
           />


### PR DESCRIPTION
### Description

<!-- Describe, at a high level, what changes you made and why -->
To be consistent with portal proposal and just because it's redundant info, removed status icons at service level where connection buttons appear.

### Checklist

<!-- Please make sure all the boxes below are checked or removed if not relevant -->

- [x] Pull Request title is in the format `[PROJ-12345] Some useful description here...`
- [ ] ~~I have prefixed this PR with `[WIP]` if it is a Work In Progress (not ready to merge)~~
- [x] The git branch is in the format `PROJ-12345-some-useful-description-here`
- [x] I have added one or more reviewers
- [ ] ~~I have added/updated tests for any code changes~~
- [ ] ~~I have updated documentation (including README, inline comments and docs.remote.it docs)~~
- [x] This PR only contains one isolated change (bug fix, feature, etc)
- [ ] ~~Translation strings added/updated for all user-visible text~~
- [x] I have manually reviewed this PR to make sure only the files I intended to change were changed and nothing else
- [x] I have notified reviewers on Slack by @ mentioning them in the `#desktop`channel
- [x] I have moved the Jira ticket into `Resolved` state and made a note in the ticket with a link to this PR

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Sign in
2. Go to service
3. See no service level icon

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/DESK-455>
