### PR TITLE
[DESK-456] Fix connection sorting

### DIFF
--- a/backend/src/ConnectionPool.ts
+++ b/backend/src/ConnectionPool.ts
@@ -122,12 +122,13 @@ export default class ConnectionPool {
   toJSON = (): IConnection[] => {
     return this.pool
       .map(c => c.toJSON())
-      .sort((a, b) => this.sort(a.createdTime, b.createdTime))
-      .sort((a, b) => this.sort(a.startTime, b.startTime))
-    // .sort(a => (a.active ? -1 : 1))
+      .sort((a, b) => {
+        return this.sort(a.active, b.active) || this.sort(a.startTime, b.startTime)
+      })
   }
 
-  sort = (a: number = 0, b: number = 0) => (a && b ? b - a : 0)
+  //@ts-ignore - you can do math with booleans
+  sort = (a: number | boolean = 0, b: number | boolean = 0) => b - a
 
   nextFreePort = async () => {
     const usedPorts = this.usedPorts


### PR DESCRIPTION
### Description

<!-- Describe, at a high level, what changes you made and why -->
Sorting of disconnected devices was backwards.
Sorting should be by connected state, then most recent connection.

### Checklist

<!-- Please make sure all the boxes below are checked or removed if not relevant -->

- [x] Pull Request title is in the format `[PROJ-12345] Some useful description here...`
- [ ] ~~I have prefixed this PR with `[WIP]` if it is a Work In Progress (not ready to merge)~~
- [x] The git branch is in the format `PROJ-12345-some-useful-description-here`
- [x] I have added one or more reviewers
- [ ] ~~I have added/updated tests for any code changes~~
- [ ] ~~I have updated documentation (including README, inline comments and docs.remote.it docs)~~
- [x] This PR only contains one isolated change (bug fix, feature, etc)
- [ ] ~~Translation strings added/updated for all user-visible text~~
- [x] I have manually reviewed this PR to make sure only the files I intended to change were changed and nothing else
- [x] I have notified reviewers on Slack by @ mentioning them in the `#desktop`channel
- [x] I have moved the Jira ticket into `Resolved` state and made a note in the ticket with a link to this PR

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Sign in
2. Go to connections page
3. Connect and disconnect from services
4. Notice sorting follows sort rules above

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/DESK-456>
