### PR TITLE
[DESK-497] Add Synchronization during uninstall for signout of frontend

### DIFF
--- a/backend/src/Application.ts
+++ b/backend/src/Application.ts
@@ -5,7 +5,7 @@ import remoteitInstaller from './remoteitInstaller'
 import environment from './environment'
 import Logger from './Logger'
 import cli from './cliInterface'
-import user from './User'
+import user, { User } from './User'
 import server from './server'
 import Tracker from './Tracker'
 import EventBus from './EventBus'
@@ -28,8 +28,8 @@ export default class Application {
     this.startHeartbeat()
     if (server.io) new Controller(server.io, this.pool)
 
-    EventBus.on(user.EVENTS.signedIn, this.check)
-    EventBus.on(user.EVENTS.signedOut, this.handleSignedOut)
+    EventBus.on(User.EVENTS.signedIn, this.check)
+    EventBus.on(User.EVENTS.signedOut, this.handleSignedOut)
   }
 
   quit() {

--- a/backend/src/CLI.ts
+++ b/backend/src/CLI.ts
@@ -8,7 +8,7 @@ import Command from './Command'
 import Logger from './Logger'
 import debug from 'debug'
 import path from 'path'
-import user from './User'
+import user, { User } from './User'
 import { removeDeviceName } from './helpers/nameHelper'
 
 const d = debug('r3:backend:CLI')
@@ -38,7 +38,7 @@ export default class CLI {
     Logger.info('ADMIN FILE', { path: path.join(environment.adminPath, 'config.json') })
     this.userConfigFile = new JSONFile<ConfigFile>(path.join(environment.userPath, 'config.json'))
     this.adminConfigFile = new JSONFile<ConfigFile>(path.join(environment.adminPath, 'config.json'))
-    EventBus.on(user.EVENTS.signedOut, () => this.signOut())
+    EventBus.on(User.EVENTS.signedOut, () => this.signOut())
     this.read()
   }
 

--- a/backend/src/User.ts
+++ b/backend/src/User.ts
@@ -11,7 +11,7 @@ import { r3 } from './remote.it'
 const d = debug('r3:backend:User')
 
 export class User {
-  EVENTS = {
+  static EVENTS = {
     signInError: 'user/sign-in/error',
     signedOut: 'signed-out',
     signedIn: 'signed-in',
@@ -53,7 +53,7 @@ export class User {
 
   authenticated() {
     this.signedIn = true
-    EventBus.emit(this.EVENTS.signedIn, this.credentials)
+    EventBus.emit(User.EVENTS.signedIn, this.credentials)
   }
 
   checkSignIn = async (credentials?: UserCredentials) => {
@@ -83,7 +83,7 @@ export class User {
     this.username = user.username
     this.authHash = user.authHash
 
-    EventBus.emit(this.EVENTS.signedIn, user)
+    EventBus.emit(User.EVENTS.signedIn, user)
 
     return user
   }
@@ -99,7 +99,8 @@ export class User {
     this.authHash = ''
     this.signedIn = false
 
-    EventBus.emit(this.EVENTS.signedOut)
+    EventBus.emit(User.EVENTS.signedOut)
+    // await delay(1000)
   }
 
   clearAll = () => {
@@ -107,5 +108,9 @@ export class User {
     cli.signOut(true)
   }
 }
+
+// function delay(ms: number) {
+//   return new Promise(resolve => setTimeout(resolve, ms))
+// }
 
 export default new User()

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -10,7 +10,7 @@ import EventBus from './EventBus'
 import Tracker from './Tracker'
 import Logger from './Logger'
 import LAN from './LAN'
-import user from './User'
+import user, { User } from './User'
 import cli from './cliInterface'
 import { hostName } from './helpers/nameHelper'
 import { IP_PRIVATE } from './constants'
@@ -47,4 +47,17 @@ export default new Application()
 
 // To support Electron wrapper
 export { EVENTS } from './electronInterface'
-export { ConnectionPool, environment, EventBus, hostName, preferences, Logger, user, cli, LAN, IP_PRIVATE, WEB_DIR }
+export {
+  ConnectionPool,
+  environment,
+  EventBus,
+  hostName,
+  preferences,
+  Logger,
+  User,
+  user,
+  cli,
+  LAN,
+  IP_PRIVATE,
+  WEB_DIR,
+}

--- a/common/types.d.ts
+++ b/common/types.d.ts
@@ -6,6 +6,7 @@ declare global {
     // user/auth
     | 'user/check-sign-in'
     | 'user/sign-in'
+    | 'user/sign-out-complete'
     | 'user/sign-out'
     | 'user/clear-all'
     | 'user/quit'

--- a/frontend/src/models/auth.ts
+++ b/frontend/src/models/auth.ts
@@ -3,6 +3,7 @@ import { parse } from 'url'
 import { IUser } from 'remote.it'
 import { createModel } from '@rematch/core'
 import { clearUserCredentials, updateUserCredentials, r3 } from '../services/remote.it'
+import { emit } from '../services/Controller'
 
 const USER_KEY = 'user'
 
@@ -103,13 +104,15 @@ export default createModel({
     /**
      * Gets called when the backend signs the user out
      */
-    async signedOut() {
+    signedOut() {
       dispatch.auth.signOutFinished()
       dispatch.devices.reset()
       dispatch.logs.reset()
       dispatch.auth.setAuthenticated(false)
-      Controller.close()
       window.location.search = ''
+      console.log('SIGNOUT COMPLETE')
+      emit('user/sign-out-complete')
+      Controller.close()
     },
   }),
   reducers: {

--- a/src/TrayMenu.ts
+++ b/src/TrayMenu.ts
@@ -4,6 +4,7 @@ import headless, {
   LAN,
   environment,
   EventBus,
+  User,
   user,
   ConnectionPool,
   hostName,
@@ -31,8 +32,8 @@ export default class TrayMenu {
       })
     }
 
-    EventBus.on(user.EVENTS.signedIn, this.render)
-    EventBus.on(user.EVENTS.signedOut, this.render)
+    EventBus.on(User.EVENTS.signedIn, this.render)
+    EventBus.on(User.EVENTS.signedOut, this.render)
     EventBus.on(ConnectionPool.EVENTS.updated, this.updatePool)
     EventBus.on(LAN.EVENTS.privateIP, privateIP => (this.privateIP = privateIP))
   }


### PR DESCRIPTION
### Description

Uninstall does not consistently log out the user.  When reopening the app the user is still signed in.  Upon investigation it appears that the front end was being killed before it could sign out.  Added Synchronization during uninstall for signout of frontend

### Checklist

<!-- Please make sure all the boxes below are checked or removed if not relevant -->

- [x] Pull Request title is in the format `[PROJ-12345] Some useful description here...`
- [x] I have prefixed this PR with `[WIP]` if it is a Work In Progress (not ready to merge)
- [x] The git branch is in the format `PROJ-12345-some-useful-description-here`
- [x] I have added one or more reviewers
- [n/a] I have added/updated tests for any code changes
- [x] I have updated documentation (including README, inline comments and docs.remote.it docs)
- [x] This PR only contains one isolated change (bug fix, feature, etc)
- [n/a] Translation strings added/updated for all user-visible text
- [x] I have manually reviewed this PR to make sure only the files I intended to change were changed and nothing else
- [x] I have notified reviewers on Slack by @ mentioning them in the `#desktop`channel
- [x] I have moved the Jira ticket into `Resolved` state and made a note in the ticket with a link to this PR

### Test plan

1. Sign in
2. Install Command Line Tools
3. Got to Settings
4. Uninstall Command Line Tools
5. You should be signed out and app close
6. Relaunch the app
7. You should be signed out

### Ticket

https://remoteit.atlassian.net/browse/DESK-497
