### PR TITLE
[DESK-490] setting manufacture-id on add and setup commands

### DIFF
--- a/backend/src/Application.ts
+++ b/backend/src/Application.ts
@@ -23,6 +23,7 @@ export default class Application {
   async constructorSync() {
     this.bindExitHandlers()
     await environment.setElevatedState()
+    cli.setManufactureId()
     remoteitInstaller.check(true)
     server.start()
     this.startHeartbeat()

--- a/backend/src/Application.ts
+++ b/backend/src/Application.ts
@@ -23,7 +23,6 @@ export default class Application {
   async constructorSync() {
     this.bindExitHandlers()
     await environment.setElevatedState()
-    cli.setManufactureId()
     remoteitInstaller.check(true)
     server.start()
     this.startHeartbeat()

--- a/backend/src/CLI.ts
+++ b/backend/src/CLI.ts
@@ -95,11 +95,7 @@ export default class CLI {
   }
 
   async addTarget(t: ITarget) {
-    await this.exec({
-      cmds: [`add "${t.name}" ${t.port} --type ${t.type} --hostname ${t.hostname || '127.0.0.1'}`],
-      admin: true,
-      checkSignIn: true,
-    })
+    await this.exec({ cmds: [this.addString(t)], admin: true, checkSignIn: true })
     this.readTargets()
   }
 
@@ -109,17 +105,27 @@ export default class CLI {
   }
 
   async register(device: IDevice) {
-    await this.exec({ cmds: [`-j setup "${device.name}"`], admin: true, checkSignIn: true })
+    await this.exec({ cmds: [this.setupString(device)], admin: true, checkSignIn: true })
     this.read()
   }
 
   async registerAll(registration: IRegistration) {
-    let cmds = [`-j setup "${registration.device.name}"`]
+    let cmds = [this.setupString(registration.device)]
     registration.targets.forEach((t: ITarget) => {
-      cmds.push(`add "${t.name}" ${t.port} --type ${t.type} --hostname ${t.hostname || '127.0.0.1'}`)
+      cmds.push(this.addString(t))
     })
     await this.exec({ cmds, admin: true, checkSignIn: true })
     this.read()
+  }
+
+  setupString(device: IDevice) {
+    return `-j --manufacture-id ${environment.manufactureId} setup "${device.name}"`
+  }
+
+  addString(t: ITarget) {
+    return `-j --manufacture-id ${environment.manufactureId} add "${t.name}" ${t.port} --type ${t.type} --hostname ${
+      t.hostname || '127.0.0.1'
+    }`
   }
 
   async delete() {

--- a/backend/src/constants.ts
+++ b/backend/src/constants.ts
@@ -24,6 +24,10 @@ export const CLI_DOWNLOAD = 'AWS' // AWS or GitHub
 export const IP_OPEN: ipAddress = '0.0.0.0'
 export const IP_PRIVATE: ipAddress = '127.0.0.1'
 
+// CLI product tracking codes
+export const MANUFACTURE_ID_STANDARD = 32770
+export const MANUFACTURE_ID_HEADLESS = 32777
+
 // Web directory
 export const WEB_DIR = path.join(__dirname, '../build')
 

--- a/backend/src/environment.ts
+++ b/backend/src/environment.ts
@@ -1,4 +1,4 @@
-import { PATHS } from './constants'
+import { PATHS, MANUFACTURE_ID_HEADLESS, MANUFACTURE_ID_STANDARD } from './constants'
 import isElevated from 'is-elevated'
 import detectRPi from 'detect-rpi'
 import os from 'os'
@@ -13,6 +13,7 @@ export class Environment {
   isPi: boolean
   isPiZero: boolean
   simpleOS: Ios
+  manufactureId: number
   privateIP: ipAddress = ''
   adminUsername: string = ''
   userPath: string
@@ -33,6 +34,7 @@ export class Environment {
     this.isLinux = os.platform() === 'linux'
     this.isArmLinux = this.isLinux && os.arch() === 'arm64'
     this.simpleOS = this.setSimpleOS()
+    this.manufactureId = this.isHeadless ? MANUFACTURE_ID_HEADLESS : MANUFACTURE_ID_STANDARD
 
     if (this.isWindows) {
       this.userPath = PATHS.WIN_USER_SETTINGS


### PR DESCRIPTION
### Description

<!-- Describe, at a high level, what changes you made and why -->
To track the difference between headless and standard desktop

### Checklist

<!-- Please make sure all the boxes below are checked or removed if not relevant -->

- [x] Pull Request title is in the format `[PROJ-12345] Some useful description here...`
- [ ] ~~I have prefixed this PR with `[WIP]` if it is a Work In Progress (not ready to merge)~~
- [x] The git branch is in the format `PROJ-12345-some-useful-description-here`
- [x] I have added one or more reviewers
- [ ] ~~I have added/updated tests for any code changes~~
- [ ] ~~I have updated documentation (including README, inline comments and docs.remote.it docs)~~
- [x] This PR only contains one isolated change (bug fix, feature, etc)
- [ ] ~~Translation strings added/updated for all user-visible text~~
- [x] I have manually reviewed this PR to make sure only the files I intended to change were changed and nothing else
- [x] I have notified reviewers on Slack by @ mentioning them in the `#desktop`channel
- [x] I have moved the Jira ticket into `Resolved` state and made a note in the ticket with a link to this PR

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. setup and add a service to a device
2. Look into the logs at the commands for the manufacturer-id option and data

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/DESK-490>
