### PR TITLE
[DESK-522] protect against segment errors

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteit-headless",
-  "version": "2.5.24-alpha.10",
+  "version": "2.5.24-alpha.11",
   "private": true,
   "main": "build/index.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteit-desktop-frontend",
-  "version": "2.5.24-alpha.10",
+  "version": "2.5.24-alpha.11",
   "private": true,
   "main": "src/server/initialize.js",
   "scripts": {

--- a/frontend/src/helpers/Analytics.ts
+++ b/frontend/src/helpers/Analytics.ts
@@ -116,21 +116,29 @@ export class Analytics {
   }
 
   public page = (pageName: string, additionalContext?: any) => {
-    this.setGAAppVersion()
-    let localContext = this.context
-    if (additionalContext) {
-      localContext = { ...additionalContext, ...localContext }
+    try {
+      this.setGAAppVersion()
+      let localContext = this.context
+      if (additionalContext) {
+        localContext = { ...additionalContext, ...localContext }
+      }
+      window.analytics.page(pageName, localContext)
+    } catch (e) {
+      console.log('Error sending data to Segment: ' + e)
     }
-    window.analytics.page(pageName, localContext)
   }
 
   public track(trackName: string, additionalContext?: any) {
-    this.setGAAppVersion()
-    let localContext = this.context
-    if (additionalContext) {
-      localContext = { ...additionalContext, ...localContext }
+    try {
+      this.setGAAppVersion()
+      let localContext = this.context
+      if (additionalContext) {
+        localContext = { ...additionalContext, ...localContext }
+      }
+      window.analytics.track(trackName, localContext)
+    } catch (e) {
+      console.log('Error sending data to Segment: ' + e)
     }
-    window.analytics.track(trackName, localContext)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteit-desktop",
-  "version": "2.5.24-alpha.10",
+  "version": "2.5.24-alpha.11",
   "private": true,
   "main": "build/index.js",
   "description": "remote.it cross platform desktop application for creating and hosting connections",


### PR DESCRIPTION
### Description

We are getting some segment errors in the field.  We need to wrap the segment calls in a try catch to keep them from interrupting the user.

### Checklist

- [x] Pull Request title is in the format `[PROJ-12345] Some useful description here...`
- [x] The git branch is in the format `PROJ-12345-some-useful-description-here`
- [x] I have added one or more reviewers
- [x] This PR only contains one isolated change (bug fix, feature, etc)
- [x] I have manually reviewed this PR to make sure only the files I intended to change were changed and nothing else
- [x] I have notified reviewers on Slack by @ mentioning them in the `#desktop`channel
- [x] I have moved the Jira ticket into `Resolved` state and made a note in the ticket with a link to this PR

### Test plan

1. Sign in to segments.io
2. Launch Desktop
3. make a connection
4. Verify page view and connection attempt are logged in segment and no errors occures

### Ticket

https://remoteit.atlassian.net/browse/DESK-522
