### PR TITLE
[DESK-534] Set loading state on setup page to account for device list loading and set device name on completion

### DIFF
--- a/frontend/src/pages/SetupDevice/SetupDevice.tsx
+++ b/frontend/src/pages/SetupDevice/SetupDevice.tsx
@@ -54,6 +54,8 @@ export const SetupDevice: React.FC<Props> = ({ os, device }) => {
 
   useEffect(() => {
     analytics.track('networkScan')
+    // Refresh device data
+    emit('device')
     emit('scan', 'localhost')
   }, [])
 

--- a/frontend/src/pages/SetupWaiting/SetupWaiting.tsx
+++ b/frontend/src/pages/SetupWaiting/SetupWaiting.tsx
@@ -26,7 +26,7 @@ export const SetupWaiting: React.FC<Props> = ({ device, os }) => {
     devices.fetch(false)
   }
 
-  if (cliError) history.push('/settings/setupDevice')
+  if (cliError) history.push('/settings')
 
   return (
     <Container header={<Breadcrumbs />}>

--- a/readme.md
+++ b/readme.md
@@ -83,7 +83,7 @@ Also a user in guest view can be logged out if the primary user logs in.
 
 ## Troubleshooting
 
-If things aren't working the best way to clear everything and start over is to use the "Uninstall command line tools" menu in the advanced settings screen.
+If things aren't working the best way to clear everything and start over is to use the **Uninstall command line tools** menu in the advanced settings screen.
 
 **CLI tools**
 


### PR DESCRIPTION

### Description

<!-- Describe, at a high level, what changes you made and why -->
Set loading state on setup page to account for device list loading and set device name on completion

### Checklist

<!-- Please make sure all the boxes below are checked or removed if not relevant -->

- [x] Pull Request title is in the format `[PROJ-12345] Some useful description here...`
- [ ] ~~I have prefixed this PR with `[WIP]` if it is a Work In Progress (not ready to merge)~~
- [x] The git branch is in the format `PROJ-12345-some-useful-description-here`
- [x] I have added one or more reviewers
- [ ] ~~I have added/updated tests for any code changes~~
- [ ] ~~I have updated documentation (including README, inline comments and docs.remote.it docs)~~
- [x] This PR only contains one isolated change (bug fix, feature, etc)
- [ ] ~~Translation strings added/updated for all user-visible text~~
- [x] I have manually reviewed this PR to make sure only the files I intended to change were changed and nothing else
- [x] I have notified reviewers on Slack by @ mentioning them in the `#desktop`channel
- [x] I have moved the Jira ticket into `Resolved` state and made a note in the ticket with a link to this PR

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Start Desktop on a system 1 that is not registered
2. Note the hostname in the setup page
3. Go to another system or VM and register that device with the hostname of system 1
2. Go to a browser and open http://localhost:29999 on system 1
3. Login and watch the system name in the setup field start with the hostname and then change to the hostname-1 after loading completes.

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/DESK-534>
