### PR TITLE
[DESK-548] move identify to setUser

### DIFF
--- a/frontend/src/models/auth.ts
+++ b/frontend/src/models/auth.ts
@@ -44,7 +44,6 @@ export default createModel({
       if (user?.username) {
         console.log('WE HAVE A USER', user.username)
         dispatch.auth.setUser(user)
-        analytics.identify(user.id)
       } else {
         dispatch.auth.signedOut()
       }
@@ -80,7 +79,6 @@ export default createModel({
           r3.user.updateCredentials(user)
           dispatch.auth.setUser(user)
           Controller.open()
-          analytics.identify(user.id)
           analytics.track('signIn')
         })
         .catch(error => {
@@ -150,6 +148,7 @@ export default createModel({
       state.user = user
       state.signInError = undefined
       window.localStorage.setItem(USER_KEY, JSON.stringify(user))
+      analytics.identify(user.id)
       Controller.emit('authentication', { username: user.username, authHash: user.authHash })
       updateUserCredentials(user)
     },


### PR DESCRIPTION
### Description

move identify to setUser so that it consistently gets called

### Checklist

- [x] Pull Request title is in the format `[PROJ-12345] Some useful description here...`
- [x] The git branch is in the format `PROJ-12345-some-useful-description-here`
- [x] I have added one or more reviewers
- [x] This PR only contains one isolated change (bug fix, feature, etc)
- [x] I have manually reviewed this PR to make sure only the files I intended to change were changed and nothing else
- [ ] I have notified reviewers on Slack by @ mentioning them in the `#desktop`channel
- [ ] I have moved the Jira ticket into `Resolved` state and made a note in the ticket with a link to this PR

### Test plan

Sign in with new version of deskto
Verify segment events and page views are tagged with userid
Long term we need to check that userid is set in all track events in segment data for new versions

### Ticket

https://remoteit.atlassian.net/browse/DESK-548
