### PR TITLE
[DESK-547] Detect desktop only updates and start CLI system services

### DIFF
--- a/backend/src/CLI.ts
+++ b/backend/src/CLI.ts
@@ -143,6 +143,10 @@ export default class CLI {
     await this.exec({ cmds: ['service start'], admin: true, checkSignIn: true })
   }
 
+  async restartService() {
+    await this.exec({ cmds: ['-j service uninstall', '-j service install'], admin: true })
+  }
+
   async install() {
     await this.exec({ cmds: ['-j tools install --update'], admin: true })
   }

--- a/backend/src/Installer.test.ts
+++ b/backend/src/Installer.test.ts
@@ -1,6 +1,7 @@
 import binaryInstaller from './binaryInstaller'
 import Installer from './Installer'
 import environment from './environment'
+import preferences from './preferences'
 import EventBus from './EventBus'
 import cli from './cliInterface'
 import fs from 'fs'
@@ -23,6 +24,7 @@ describe('backend/Installer', () => {
         dependencies: ['connectd', 'muxer', 'demuxer'],
       })
 
+      preferences.set({ version: environment.version })
       path = installer.binaryPath()
       installSpy = jest.spyOn(binaryInstaller, 'install').mockImplementation()
       eventSpy = jest.spyOn(EventBus, 'emit').mockImplementation()
@@ -108,7 +110,7 @@ describe('backend/Installer', () => {
     test('should detect old version', async () => {
       versionSpy = jest.spyOn(cli, 'version').mockImplementation(() => Promise.resolve('0.30.1'))
 
-      const isCurrent = await installer.isCurrent()
+      const isCurrent = await installer.isCliCurrent()
 
       expect(versionSpy).toBeCalledTimes(1)
       expect(isCurrent).toBe(false)
@@ -117,7 +119,7 @@ describe('backend/Installer', () => {
     test('should detect same version', async () => {
       versionSpy = jest.spyOn(cli, 'version').mockImplementation(() => Promise.resolve('0.37.6'))
 
-      const isCurrent = await installer.isCurrent()
+      const isCurrent = await installer.isCliCurrent()
 
       expect(versionSpy).toBeCalledTimes(1)
       expect(isCurrent).toBe(true)
@@ -126,7 +128,7 @@ describe('backend/Installer', () => {
     test('should consider a bad response as not current', async () => {
       versionSpy = jest.spyOn(cli, 'version').mockImplementation(() => Promise.resolve('Error'))
 
-      const isCurrent = await installer.isCurrent()
+      const isCurrent = await installer.isCliCurrent()
 
       expect(versionSpy).toBeCalledTimes(1)
       expect(isCurrent).toBe(false)
@@ -135,7 +137,7 @@ describe('backend/Installer', () => {
     test('should consider a newer version as current', async () => {
       versionSpy = jest.spyOn(cli, 'version').mockImplementation(() => Promise.resolve('1.0.0'))
 
-      const isCurrent = await installer.isCurrent()
+      const isCurrent = await installer.isCliCurrent()
 
       expect(versionSpy).toBeCalledTimes(1)
       expect(isCurrent).toBe(true)
@@ -144,7 +146,7 @@ describe('backend/Installer', () => {
     test('should handle beta tags', async () => {
       versionSpy = jest.spyOn(cli, 'version').mockImplementation(() => Promise.resolve('0.37.7-Beta'))
 
-      const isCurrent = await installer.isCurrent()
+      const isCurrent = await installer.isCliCurrent()
 
       expect(versionSpy).toBeCalledTimes(1)
       expect(isCurrent).toBe(true)

--- a/backend/src/Installer.ts
+++ b/backend/src/Installer.ts
@@ -1,6 +1,7 @@
 import { CLI_DOWNLOAD } from './constants'
 import debug from 'debug'
 import cli from './cliInterface'
+import preferences from './preferences'
 import binaryInstaller from './binaryInstaller'
 import semverCompare from 'semver/functions/compare'
 import environment from './environment'
@@ -45,9 +46,15 @@ export default class Installer {
 
   async check(log?: boolean) {
     d('CHECK INSTALLATION', { name: this.name, version: this.version })
-    if (await this.isCurrent(log)) return EventBus.emit(Installer.EVENTS.installed, this.toJSON())
-    if (environment.isElevated) return await binaryInstaller.install()
-    EventBus.emit(Installer.EVENTS.notInstalled, this.name)
+    const cliCurrent = await this.isCliCurrent(log)
+    const desktopCurrent = this.isDesktopCurrent(log)
+
+    if (cliCurrent && desktopCurrent) {
+      return EventBus.emit(Installer.EVENTS.installed, this.toJSON())
+    } else {
+      if (environment.isElevated) await binaryInstaller.install()
+      else EventBus.emit(Installer.EVENTS.notInstalled, this.name)
+    }
   }
 
   /**
@@ -69,23 +76,35 @@ export default class Installer {
     } as InstallationInfo
   }
 
-  async isCurrent(log?: boolean) {
-    let current = false
+  isDesktopCurrent(log?: boolean) {
+    let desktopVersion = preferences.data?.version
+    let current = semverCompare(desktopVersion, environment.version) >= 0
+    if (current) {
+      log && Logger.info('DESKTOP CURRENT', { desktopVersion })
+    } else {
+      Logger.info('DESKTOP UPDATED', { oldVersion: desktopVersion, thisVersion: environment.version })
+    }
+
+    return current
+  }
+
+  async isCliCurrent(log?: boolean) {
     let cliVersion = 'Not Installed'
+    let current = false
 
     if (this.isInstalled()) {
       cliVersion = await cli.version()
       try {
         current = semverCompare(cliVersion, this.version) >= 0
       } catch (error) {
-        Logger.warn('BAD VERSION', { error })
+        Logger.warn('BAD CLI VERSION', { error })
       }
     }
 
     if (current) {
-      log && Logger.info('CHECK VERSION', { current, name: this.name, cliVersion, desiredVersion: this.version })
+      log && Logger.info('CHECK CLI VERSION', { current, name: this.name, cliVersion, desiredVersion: this.version })
     } else {
-      Logger.info('NOT CURRENT', { name: this.name, cliVersion, desiredVersion: this.version })
+      Logger.info('CLI NOT CURRENT', { name: this.name, cliVersion, desiredVersion: this.version })
     }
 
     return current

--- a/backend/src/Installer.ts
+++ b/backend/src/Installer.ts
@@ -77,7 +77,7 @@ export default class Installer {
   }
 
   isDesktopCurrent(log?: boolean) {
-    let desktopVersion = preferences.data?.version
+    let desktopVersion = preferences.get().version
     let current = semverCompare(desktopVersion, environment.version) >= 0
     if (current) {
       log && Logger.info('DESKTOP CURRENT', { desktopVersion })

--- a/backend/src/preferences.ts
+++ b/backend/src/preferences.ts
@@ -12,23 +12,23 @@ export class Preferences {
 
   constructor() {
     this.file = new JSONFile<IPreferences>(path.join(environment.userPath, 'preferences.json'))
-    if (!this.file.exists) this.file.write(this.defaults)
-    this.set(this.file.read() || {})
+    this.set({ ...this.defaults, ...this.file.read() })
     Logger.info('PREFERENCES', { preferences: this.data })
   }
 
   get defaults(): IPreferences {
     return {
+      version: environment.version,
       autoUpdate: environment.isMac || environment.isWindows,
       openAtLogin: true,
     }
   }
 
-  set = (preferences: IPreferences) => {
+  set = (preferences: IPreferences, quiet?: boolean) => {
     this.file.write(preferences)
     this.data = preferences
     Logger.info('SET PREFERENCES', { preferences })
-    EventBus.emit(this.EVENTS.update, this.data)
+    if (!quiet) EventBus.emit(this.EVENTS.update, this.data)
   }
 }
 

--- a/backend/src/preferences.ts
+++ b/backend/src/preferences.ts
@@ -24,6 +24,10 @@ export class Preferences {
     }
   }
 
+  get(): IPreferences {
+    return this.data || {}
+  }
+
   set = (preferences: IPreferences, quiet?: boolean) => {
     this.file.write(preferences)
     this.data = preferences

--- a/frontend/src/components/InstallationNotice/InstallationNotice.tsx
+++ b/frontend/src/components/InstallationNotice/InstallationNotice.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { ApplicationState } from '../../store'
 import { connect } from 'react-redux'
+import { ApplicationState } from '../../store'
 import { Button, Typography } from '@material-ui/core'
+import { isWindows } from '../../services/Browser'
 import { makeStyles } from '@material-ui/styles'
 import { spacing } from '../../styling'
 import { Body } from '../Body'
@@ -44,7 +45,7 @@ export const InstallationNotice = connect(
         </Alert>
       )}
       <Typography className={css.space} variant="h2" align="center">
-        We need to install our service onto your machine
+        We need to install or update our service
         <br />
         in order to maintain background connections.
       </Typography>
@@ -63,7 +64,7 @@ export const InstallationNotice = connect(
         <Icon name="info-circle" weight="regular" size="xs" inlineLeft />
         You will be prompted for permission to continue the installation.
         <br />
-        Run remote.it as an administrator to avoid future prompting.
+        Run remote.it {isWindows() ? 'as an administrator' : 'with sudo'} to avoid future prompting.
       </Typography>
     </Body>
   )


### PR DESCRIPTION
### Description

<!-- Describe, at a high level, what changes you made and why -->
Desktop should track it's version and run cli restart services on any update incase they get killed.

### Checklist

<!-- Please make sure all the boxes below are checked or removed if not relevant -->

- [x] Pull Request title is in the format `[PROJ-12345] Some useful description here...`
- [ ] ~~I have prefixed this PR with `[WIP]` if it is a Work In Progress (not ready to merge)~~
- [x] The git branch is in the format `PROJ-12345-some-useful-description-here`
- [x] I have added one or more reviewers
- [x] I have added/updated tests for any code changes
- [ ] ~~I have updated documentation (including README, inline comments and docs.remote.it docs)~~
- [x] This PR only contains one isolated change (bug fix, feature, etc)
- [ ] ~~Translation strings added/updated for all user-visible text~~
- [x] I have manually reviewed this PR to make sure only the files I intended to change were changed and nothing else
- [x] I have notified reviewers on Slack by @ mentioning them in the `#desktop`channel
- [x] I have moved the Jira ticket into `Resolved` state and made a note in the ticket with a link to this PR

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Startup Desktop
2. Quit Desktop
3. Find the preferences file (see readme.md)
4. Change the indicated version to an older version in the preferences file
5. Stop the services `sudo remoteit service stop`
6. Restart Desktop
7. You should see an indication that systems services need to be installed/updated
8. Device should come back online

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/DESK-547>
