### PR TITLE
[DESK-564] Hide errors from cli version checking for 2.4.7 update path

### DIFF
--- a/backend/src/CLI.ts
+++ b/backend/src/CLI.ts
@@ -207,7 +207,7 @@ export default class CLI {
       cmds.unshift(`-j signin ${user.username} -a ${user.authHash}`)
     }
     cmds.forEach(cmd => commands.push(`"${remoteitInstaller.binaryPath()}" ${cmd}`))
-    commands.onError = (e: Error) => EventBus.emit(this.EVENTS.error, e.toString())
+    if (!quiet) commands.onError = (e: Error) => EventBus.emit(this.EVENTS.error, e.toString())
 
     result = await commands.exec()
     if (readUser) this.readUser(admin)


### PR DESCRIPTION
### Description

<!-- Describe, at a high level, what changes you made and why -->
Hiding errors for cli version check that appear when updating from desktop 2.4.7 and cli 0.37.2 

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Install Desktop 2.4.7-alpha (it's attached to the Jira ticket)
2. Wait for prompting and update to latest (must be at least 2.5.32)
3. See if any errors appear

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/DESK-564>
