### PR TITLE
[DESK-565] no quiet setting of preferences is allowable

### DIFF
--- a/backend/src/binaryInstaller.ts
+++ b/backend/src/binaryInstaller.ts
@@ -32,7 +32,7 @@ class BinaryInstaller {
       await this.restartService()
     }
 
-    preferences.set({ ...preferences.data, version: environment.version }, true)
+    preferences.update({ version: environment.version })
     EventBus.emit(Installer.EVENTS.installed, remoteitInstaller.toJSON())
     this.inProgress = false
   }

--- a/backend/src/preferences.ts
+++ b/backend/src/preferences.ts
@@ -28,11 +28,15 @@ export class Preferences {
     return this.data || {}
   }
 
-  set = (preferences: IPreferences, quiet?: boolean) => {
+  update(pref: { [key: string]: any }) {
+    this.set({ ...this.data, ...pref })
+  }
+
+  set = (preferences: IPreferences) => {
     this.file.write(preferences)
     this.data = preferences
     Logger.info('SET PREFERENCES', { preferences })
-    if (!quiet) EventBus.emit(this.EVENTS.update, this.data)
+    EventBus.emit(this.EVENTS.update, this.data)
   }
 }
 

--- a/src/AutoUpdater.ts
+++ b/src/AutoUpdater.ts
@@ -1,5 +1,5 @@
 import electron from 'electron'
-import { EventBus, Logger, EVENTS, environment, preferences } from 'remoteit-headless'
+import { EventBus, Logger, EVENTS, preferences } from 'remoteit-headless'
 import { autoUpdater } from 'electron-updater'
 
 const AUTO_UPDATE_CHECK_INTERVAL = 43200000 // one half day
@@ -29,12 +29,12 @@ export default class AppUpdater {
       this.autoUpdate = autoUpdate
     })
 
-    this.autoUpdate = preferences.data?.autoUpdate
+    this.autoUpdate = preferences.get().autoUpdate
   }
 
   check(force?: boolean) {
     try {
-      if (force || (this.nextCheck < Date.now() && preferences.data?.autoUpdate)) {
+      if (force || (this.nextCheck < Date.now() && preferences.get().autoUpdate)) {
         autoUpdater.checkForUpdatesAndNotify()
         this.nextCheck = Date.now() + AUTO_UPDATE_CHECK_INTERVAL
       }


### PR DESCRIPTION
### Description

<!-- Describe, at a high level, what changes you made and why -->
When the preference update was happening it was not updating the preference value in the ui, so when a preference was changed it was resetting the desktop version back to the old version.

### Checklist

<!-- Please make sure all the boxes below are checked or removed if not relevant -->

- [x] Pull Request title is in the format `[PROJ-12345] Some useful description here...`
- [ ] ~~I have prefixed this PR with `[WIP]` if it is a Work In Progress (not ready to merge)~~
- [x] The git branch is in the format `PROJ-12345-some-useful-description-here`
- [x] I have added one or more reviewers
- [ ] ~~I have added/updated tests for any code changes~~
- [ ] ~~I have updated documentation (including README, inline comments and docs.remote.it docs)~~
- [x] This PR only contains one isolated change (bug fix, feature, etc)
- [ ] ~~Translation strings added/updated for all user-visible text~~
- [x] I have manually reviewed this PR to make sure only the files I intended to change were changed and nothing else
- [x] I have notified reviewers on Slack by @ mentioning them in the `#desktop`channel
- [x] I have moved the Jira ticket into `Resolved` state and made a note in the ticket with a link to this PR

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Install previous version
2. Check the version in the preferences file
3. Update 
4. Check the version in the preferences file
5. Change the auto update setting
6. Recheck the version in the preferences file

Version should not have changed after switching the auto-update setting.

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/DESK-565>
