### PR TITLE
[DESK-562] OOB indicator on more pages

### DIFF
--- a/frontend/src/components/OutOfBand/OutOfBand.tsx
+++ b/frontend/src/components/OutOfBand/OutOfBand.tsx
@@ -1,11 +1,17 @@
 import React, { useEffect } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
+import { useSelector } from 'react-redux'
 import { Tooltip, Link } from '@material-ui/core'
+import { ApplicationState } from '../../store'
 import { colors, spacing, fontSizes } from '../../styling'
 import { emit } from '../../services/Controller'
 
-export const OutOfBand: React.FC<{ active: boolean }> = ({ active }) => {
+export const OutOfBand: React.FC = () => {
   const css = useStyles()
+  const { available, active } = useSelector((state: ApplicationState) => ({
+    available: state.backend.lan.oobAvailable,
+    active: state.backend.lan.oobActive,
+  }))
 
   useEffect(() => {
     emit('oobCheck')
@@ -16,19 +22,28 @@ export const OutOfBand: React.FC<{ active: boolean }> = ({ active }) => {
     }
   }, [])
 
+  if (!available) return null
+
   return (
-    <Tooltip title={active ? 'Mode active' : 'Mode inactive'}>
-      <Link href="https://docs.remote.it/guides/out-of-band" target="_blank">
-        <div className={css.oob + (active ? ' ' + css.active : '')}>
-          <span />
-          <small>Out of Band</small>
-        </div>
-      </Link>
-    </Tooltip>
+    <span className={css.container}>
+      <Tooltip title={active ? 'Mode active' : 'Mode inactive'}>
+        <Link href="https://docs.remote.it/guides/out-of-band" target="_blank">
+          <div className={css.oob + (active ? ' ' + css.active : '')}>
+            <span />
+            <small>Out of Band</small>
+          </div>
+        </Link>
+      </Tooltip>
+    </span>
   )
 }
 
 const useStyles = makeStyles({
+  container: {
+    top: spacing.xs,
+    right: spacing.lg,
+    position: 'absolute',
+  },
   oob: {
     border: `1px solid ${colors.grayLight}`,
     padding: `${spacing.xxs}px ${spacing.sm}px`,

--- a/frontend/src/models/devices.ts
+++ b/frontend/src/models/devices.ts
@@ -65,8 +65,9 @@ export default createModel({
       } catch (error) {
         console.error('Fetch error:', error, error.response)
         if (error && error.response && (error.response.status === 401 || error.response.status === 403)) {
-          dispatch.backend.set({ globalError: error.message })
           dispatch.auth.checkSession()
+        } else {
+          dispatch.backend.set({ globalError: error.message })
         }
       }
 

--- a/frontend/src/pages/NetworkPage/NetworkPage.tsx
+++ b/frontend/src/pages/NetworkPage/NetworkPage.tsx
@@ -1,25 +1,18 @@
 import React, { useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import { ApplicationState } from '../../store'
-import { makeStyles } from '@material-ui/core/styles'
 import { OutOfBand } from '../../components/OutOfBand'
 import { Network } from '../../components/Network'
 import { emit } from '../../services/Controller'
-import styles from '../../styling'
 import analytics from '../../helpers/Analytics'
 
 export const NetworkPage: React.FC = () => {
-  const css = useStyles()
-  const { interfaces, targets, scanData, privateIP, oobAvailable, oobActive } = useSelector(
-    (state: ApplicationState) => ({
-      interfaces: state.backend.interfaces,
-      targets: state.backend.targets,
-      scanData: state.backend.scanData,
-      privateIP: state.backend.environment.privateIP,
-      oobAvailable: state.backend.lan.oobAvailable,
-      oobActive: state.backend.lan.oobActive,
-    })
-  )
+  const { interfaces, targets, scanData, privateIP } = useSelector((state: ApplicationState) => ({
+    interfaces: state.backend.interfaces,
+    targets: state.backend.targets,
+    scanData: state.backend.scanData,
+    privateIP: state.backend.environment.privateIP,
+  }))
   const scan = (interfaceName: string) => {
     analytics.track('networkScan')
     emit('scan', interfaceName)
@@ -32,22 +25,11 @@ export const NetworkPage: React.FC = () => {
   useEffect(() => {
     analytics.page('NetworkPage')
   }, [])
+
   return (
     <>
-      {oobAvailable && (
-        <span className={css.oob}>
-          <OutOfBand active={oobActive} />
-        </span>
-      )}
+      <OutOfBand />
       <Network data={scanData} targets={targets} interfaces={interfaces} onScan={scan} privateIP={privateIP} />
     </>
   )
 }
-
-const useStyles = makeStyles({
-  oob: {
-    top: styles.spacing.sm,
-    right: styles.spacing.lg,
-    position: 'absolute',
-  },
-})

--- a/frontend/src/pages/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage/SettingsPage.tsx
@@ -9,6 +9,7 @@ import { UninstallSetting } from '../../components/UninstallSetting'
 import { usePermissions } from '../../hooks/usePermissions'
 import { UpdateSetting } from '../../components/UpdateSetting'
 import { makeStyles } from '@material-ui/core/styles'
+import { OutOfBand } from '../../components/OutOfBand'
 import { Container } from '../../components/Container'
 import { spacing } from '../../styling'
 import { Logo } from '../../components/Logo'
@@ -52,6 +53,7 @@ export const SettingsPage = () => {
     <Container
       header={
         <>
+          <OutOfBand />
           <Typography className={css.header} variant="h1">
             <Tooltip title="Visit remote.it on the web">
               <ButtonBase onClick={() => window.open('https://remote.it')}>

--- a/frontend/src/pages/SetupServices/SetupServices.tsx
+++ b/frontend/src/pages/SetupServices/SetupServices.tsx
@@ -5,6 +5,7 @@ import { ApplicationState, Dispatch } from '../../store'
 import { CircularProgress, Tooltip, IconButton, Typography, Divider } from '@material-ui/core'
 import { NetworkScanLocation } from '../../components/NetworkScanLocation'
 import { useHistory, useRouteMatch } from 'react-router-dom'
+import { OutOfBand } from '../../components/OutOfBand'
 import { makeStyles } from '@material-ui/core/styles'
 import { Container } from '../../components/Container'
 import { Targets } from '../../components/Targets'
@@ -60,6 +61,7 @@ export const SetupServices: React.FC<Props> = ({ device, os, targets, ...props }
     <Container
       header={
         <>
+          <OutOfBand />
           <Breadcrumbs />
           <Typography variant="h1">
             <Icon name="hdd" size="lg" type="light" color="grayDarker" fixedWidth />


### PR DESCRIPTION
### Description

<!-- Describe, at a high level, what changes you made and why -->
To increase visibility added OOB indicator to the device setup and the general settings pages.

### Checklist

<!-- Please make sure all the boxes below are checked or removed if not relevant -->

- [x] Pull Request title is in the format `[PROJ-12345] Some useful description here...`
- [x] The git branch is in the format `PROJ-12345-some-useful-description-here`
- [x] I have added one or more reviewers
- [x] I have manually reviewed this PR to make sure only the files I intended to change were changed and nothing else
- [x] I have notified reviewers on Slack by @ mentioning them in the `#desktop`channel
- [x] I have moved the Jira ticket into `Resolved` state and made a note in the ticket with a link to this PR

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Sign in to a remoteit Pi that has out of band activated
2. Configure for out of band mode ... needs two networks connected
3. You should see the indicator on the settings page, the device services setup page (after registered) and the network scan page.

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/DESK-562>
