### PR TITLE
[DESK-633] If failover hasn't been set, default it to true

### DIFF
--- a/backend/src/Connection.ts
+++ b/backend/src/Connection.ts
@@ -24,8 +24,11 @@ export default class Connection extends EventEmitter {
     this.set(connection)
   }
 
-  async set({ host = IP_PRIVATE, restriction = IP_OPEN, ...connection }: IConnection, setCLI?: boolean) {
-    this.params = { host, restriction, ...connection }
+  async set(
+    { host = IP_PRIVATE, restriction = IP_OPEN, failover = true, ...connection }: IConnection,
+    setCLI?: boolean
+  ) {
+    this.params = { host, restriction, failover, ...connection }
     Logger.info('SET CONNECTION', { params: this.params })
     if (setCLI) await cli.setConnection(this.params)
   }

--- a/backend/src/cliStrings.ts
+++ b/backend/src/cliStrings.ts
@@ -33,7 +33,11 @@ export default {
   },
 
   connect(c: IConnection) {
-    return `-j connection add --id ${c.id} --name "${c.name}" --port ${c.port} --hostname ${c.host} --restrict ${c.restriction} --retry ${c.autoStart} --failover ${c.failover} --authhash ${user.authHash} --manufacture-id ${environment.appCode}`
+    return `-j connection add --id ${c.id} --name "${c.name}" --port ${c.port} --hostname ${c.host} --restrict ${
+      c.restriction
+    } --retry ${!!c.autoStart} --failover ${!!c.failover} --authhash ${user.authHash} --manufacture-id ${
+      environment.appCode
+    }`
   },
 
   disconnect(c: IConnection) {
@@ -41,7 +45,11 @@ export default {
   },
 
   setConnect(c: IConnection) {
-    return `-j connection modify --id ${c.id} --name "${c.name}" --port ${c.port} --hostname ${c.host} --restrict ${c.restriction} --retry ${c.autoStart} --failover ${c.failover} --enable ${c.active} --authhash ${user.authHash} --manufacture-id ${environment.appCode}`
+    return `-j connection modify --id ${c.id} --name "${c.name}" --port ${c.port} --hostname ${c.host} --restrict ${
+      c.restriction
+    } --retry ${!!c.autoStart} --failover ${!!c.failover} --enable ${!!c.active} --authhash ${
+      user.authHash
+    } --manufacture-id ${environment.appCode}`
   },
 
   serviceInstall() {


### PR DESCRIPTION
### Description

<!-- Describe, at a high level, what changes you made and why -->
If failover hasn't been set, default it to true

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Start with previous version of desktop
2. Start a new connection
3. Update to the latest version
4. You should see the proxy failover setting set to true

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->
<https://remoteit.atlassian.net/browse/DESK-633>
