### PR TITLE
[DESK-634] clear connecting

### DIFF
--- a/backend/src/CLI.ts
+++ b/backend/src/CLI.ts
@@ -109,6 +109,7 @@ export default class CLI {
       createdTime: Math.round(c.createdtimestamp / 1000000),
       startTime: Math.round((c.startedtimestamp || c.createdtimestamp) / 1000000),
       endTime: Math.round(c.stoppedtimestamp / 1000000),
+      connecting: false,
       restriction: c.restrict,
       autoStart: c.retry,
       failover: c.failover,

--- a/backend/src/Connection.ts
+++ b/backend/src/Connection.ts
@@ -43,10 +43,7 @@ export default class Connection extends EventEmitter {
     EventBus.emit(Connection.EVENTS.connected, { connection: this.params, raw: 'Connected' })
   }
 
-  async stop(autoStart?: boolean) {
-    // manually stopped don't auto start future connections
-    if (autoStart !== undefined) this.params.autoStart = autoStart
-
+  async stop() {
     d('Stopping service:', this.params.id)
 
     this.params.active = false

--- a/backend/src/ConnectionPool.ts
+++ b/backend/src/ConnectionPool.ts
@@ -102,10 +102,10 @@ export default class ConnectionPool {
     this.updated()
   }
 
-  stop = async ({ id }: IConnection, autoStart?: boolean) => {
+  stop = async ({ id }: IConnection) => {
     d('STOPPING CONNECTION:', id)
     const instance = this.find(id)
-    instance && instance.stop(autoStart)
+    instance && instance.stop()
   }
 
   forget = async ({ id }: IConnection) => {
@@ -144,7 +144,10 @@ export default class ConnectionPool {
     return this.pool
       .map(c => c.params)
       .sort((a, b) => {
-        return this.sort(a.active, b.active) || this.sort(a.startTime, b.startTime)
+        return (
+          this.sort(a.active, b.active) ||
+          (a.active ? this.sort(a.startTime, b.startTime) : this.sort(a.endTime, b.endTime))
+        )
       })
   }
 

--- a/backend/src/Controller.ts
+++ b/backend/src/Controller.ts
@@ -152,7 +152,7 @@ class Controller {
 
   disconnect = async (connection: IConnection) => {
     Logger.info('DISCONNECT', { id: connection.id })
-    await this.pool.stop(connection, false)
+    await this.pool.stop(connection)
   }
 
   forget = async (connection: IConnection) => {
@@ -166,7 +166,7 @@ class Controller {
   }
 
   restart = () => {
-    Logger.info('WEB UI AUTOUPDATE RESTART')
+    Logger.info('WEB UI AUTO UPDATE RESTART')
     app.restart()
   }
 

--- a/frontend/src/components/ConnectionErrorMessage/ConnectionErrorMessage.tsx
+++ b/frontend/src/components/ConnectionErrorMessage/ConnectionErrorMessage.tsx
@@ -2,15 +2,7 @@ import React from 'react'
 import { useHistory } from 'react-router'
 import { makeStyles } from '@material-ui/core/styles'
 import { clearConnectionError } from '../../helpers/connectionHelper'
-import {
-  ListItem,
-  ListItemIcon,
-  ListItemText,
-  ListItemSecondaryAction,
-  Tooltip,
-  Button,
-  Collapse,
-} from '@material-ui/core'
+import { ListItem, ListItemIcon, ListItemText, Tooltip, Collapse } from '@material-ui/core'
 import { IconButton } from '@material-ui/core'
 import { Icon } from '../Icon'
 import styles from '../../styling'
@@ -45,11 +37,6 @@ export const ConnectionErrorMessage: React.FC<Props> = ({ connection, service, v
         >
           Connection Error
         </ListItemText>
-        <ListItemSecondaryAction>
-          <Button onClick={viewLog} size="small">
-            View Log
-          </Button>
-        </ListItemSecondaryAction>
       </ListItem>
     </Collapse>
   )

--- a/frontend/src/pages/ServicePage/ServicePage.tsx
+++ b/frontend/src/pages/ServicePage/ServicePage.tsx
@@ -116,7 +116,6 @@ export const ServicePage: React.FC = () => {
         <LanShareSelect connection={connection} service={service} />
         <ProxySetting connection={connection} service={service} />
         <AutoStartSetting connection={connection} service={service} />
-        <ConnectionLog connection={connection} />
       </List>
       <Divider />
       <Columns inset>


### PR DESCRIPTION
### Description

<!-- Describe, at a high level, what changes you made and why -->

Removing access to logs, since we aren't getting logs from cli
Remove turning off auto start on disconnect. CLI reconnect behavior is different
Default to not connecting when reading cli connection state
Fix disconnected connection sort order

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

Under some circumstances with cli was exiting early we would read in the cli results before clearing the connection state. This fixes that issue.

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/DESK-634>
