### PR TITLE
[DESK-637] show installed cli version

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteit-headless",
-  "version": "2.7.0-alpha.0",
+  "version": "2.7.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "remoteit-headless",
-    "version": "2.7.0-alpha.0",
+    "version": "2.7.0-alpha.1",
     "private": true,
     "main": "build/index.js",
     "scripts": {

--- a/backend/src/Command.ts
+++ b/backend/src/Command.ts
@@ -33,13 +33,13 @@ export default class Command {
     if (!this.quiet) Logger[type](message, params)
   }
 
-  parseCliErrors(stderr: string) {
-    const jsonError = stderr.substring(0, stderr.indexOf('}') + 1)
+  parseCliErrors(error: string) {
+    const jsonError = error.match(/{.*}/)
     if (jsonError) {
-      const { details }: CliStderr = JSON.parse(jsonError)
+      const { details }: CliStderr = JSON.parse(jsonError[0])
       return details.join('\n')
     }
-    return stderr
+    return error
   }
 
   async exec() {
@@ -80,8 +80,8 @@ export default class Command {
         error,
       })
       this.log(`EXEC CAUGHT *** ERROR ***`, { error, errorMessage: error.message }, 'error')
-      this.onError(error)
-      result = error.toString()
+      result = this.parseCliErrors(error.message)
+      this.onError(new Error(result))
     }
 
     return result

--- a/backend/src/Installer.test.ts
+++ b/backend/src/Installer.test.ts
@@ -48,7 +48,21 @@ describe('backend/Installer', () => {
 
       expect(installSpy).toBeCalledTimes(0)
       expect(eventSpy).toBeCalledTimes(1)
-      expect(eventSpy).toBeCalledWith('binary/installed', { path, version, name })
+      expect(eventSpy).toBeCalledWith('binary/installed', { path, version, name, installedVersion: version })
+      expect(versionSpy).toBeCalledTimes(1)
+    })
+
+    test('should notify with different installed version', async () => {
+      const installedVersion = '0.40.0'
+
+      jest.spyOn(fs, 'existsSync').mockImplementation(() => true)
+      versionSpy = jest.spyOn(cli, 'version').mockImplementation(() => Promise.resolve(installedVersion))
+
+      await installer.check()
+
+      expect(installSpy).toBeCalledTimes(0)
+      expect(eventSpy).toBeCalledTimes(1)
+      expect(eventSpy).toBeCalledWith('binary/installed', { path, version, name, installedVersion })
       expect(versionSpy).toBeCalledTimes(1)
     })
 

--- a/backend/src/Installer.ts
+++ b/backend/src/Installer.ts
@@ -27,6 +27,7 @@ export default class Installer {
   name: string
   repoName: string
   version: string
+  installedVersion?: string
   dependencies: string[]
   tempFile?: string
 
@@ -73,6 +74,7 @@ export default class Installer {
       path: this.binaryPath(),
       version: this.version,
       name: this.name,
+      installedVersion: this.installedVersion,
     } as InstallationInfo
   }
 
@@ -94,6 +96,7 @@ export default class Installer {
 
     if (this.isInstalled()) {
       cliVersion = await cli.version()
+      this.installedVersion = cliVersion
       try {
         current = semverCompare(cliVersion, this.version) >= 0
       } catch (error) {

--- a/backend/src/cliStrings.ts
+++ b/backend/src/cliStrings.ts
@@ -25,7 +25,7 @@ export default {
   },
 
   remove(t: ITarget) {
-    return `remove --id ${t.uid} --authhash ${user.authHash}`
+    return `-j remove --id ${t.uid} --authhash ${user.authHash}`
   },
 
   teardown() {

--- a/backend/src/constants.ts
+++ b/backend/src/constants.ts
@@ -6,8 +6,6 @@ export const ENVIRONMENT = process.env.NODE_ENV || 'production'
 export const PRODUCT_NAME = 'Desktop'
 export const MANUFACTURER_NAME = 'remote.it'
 export const REMOTEIT_PI_WIFI = 'remote.itPi'
-
-// Google Analytics usage tracking
 export const HEARTBEAT_INTERVAL = 1000 * 60 // 1 bmp
 
 // Airbrake error reporting
@@ -15,7 +13,7 @@ export const AIRBRAKE_PROJECT_ID = 223457
 export const AIRBRAKE_PROJECT_KEY = process.env.AIRBRAKE_PROJECT_KEY || 'e1376551dbe5b1326f98edd78b6247ba'
 
 // CLI
-export const CLI_VERSION = '1.2.30'
+export const CLI_VERSION = '1.3.0'
 export const CLI_DOWNLOAD: 'AWS' | 'GitHub' = 'AWS' // AWS or GitHub
 
 // CLI product tracking codes

--- a/common/types.d.ts
+++ b/common/types.d.ts
@@ -98,6 +98,7 @@ declare global {
     name: string
     path: string
     version: string
+    installedVersion?: string
   }
 
   interface UserCredentials {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteit-desktop-frontend",
-  "version": "2.7.0-alpha.0",
+  "version": "2.7.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteit-desktop-frontend",
-  "version": "2.7.0-alpha.0",
+  "version": "2.7.0-alpha.1",
   "private": true,
   "main": "src/server/initialize.js",
   "scripts": {

--- a/frontend/src/components/App/App.tsx
+++ b/frontend/src/components/App/App.tsx
@@ -17,11 +17,7 @@ import styles from '../../styling'
 
 export const App: React.FC = () => {
   const { installed, signedOut, uninstalling } = useSelector((state: ApplicationState) => ({
-    installed:
-      state.binaries.connectdInstalled &&
-      state.binaries.muxerInstalled &&
-      state.binaries.demuxerInstalled &&
-      state.binaries.remoteitInstalled,
+    installed: state.binaries.installed,
     signedOut: (!state.auth.user || !state.auth.authenticated) && !state.auth.loadingInitialState,
     uninstalling: state.ui.uninstalling,
   }))

--- a/frontend/src/components/ScanNetwork/ScanNetwork.tsx
+++ b/frontend/src/components/ScanNetwork/ScanNetwork.tsx
@@ -36,7 +36,7 @@ const InterfaceIcon: IInterfaceIcon = {
   FireWire: <Icon name="fire" type="regular" />,
   Thunderbolt: <Icon name="bolt" type="regular" />,
   Bluetooth: <Icon name="bluetooth-b" type="regular" />,
-  Other: <Icon name="usb" type="regular" />,
+  Other: <Icon name="usb" type="brands" />,
 }
 
 export const ScanNetwork: React.FC<Props> = ({ data, targets, interfaceType, privateIP }) => {

--- a/frontend/src/models/binaries.ts
+++ b/frontend/src/models/binaries.ts
@@ -5,37 +5,19 @@ import analytics from '../helpers/Analytics'
 export interface BinariesState {
   error?: any
   installing: boolean
-  connectdInstalled: boolean
-  connectdPath?: string
-  connectdVersion?: string
-  muxerInstalled: boolean
-  muxerPath?: string
-  muxerVersion?: string
-  demuxerInstalled: boolean
-  demuxerPath?: string
-  demuxerVersion?: string
-  demuxerErrork?: string
-  remoteitInstalled: boolean
-  remoteitPath?: string
-  remoteitVersion?: string
-  remoteitErrork?: string
+  installed: boolean
+  path?: string
+  version?: string
+  installedVersion?: string
 }
 
 const state: BinariesState = {
   error: undefined,
   installing: false,
-  connectdInstalled: true,
-  connectdPath: undefined,
-  connectdVersion: undefined,
-  muxerInstalled: true,
-  muxerPath: undefined,
-  muxerVersion: undefined,
-  demuxerInstalled: true,
-  demuxerPath: undefined,
-  demuxerVersion: undefined,
-  remoteitInstalled: true,
-  remoteitPath: undefined,
-  remoteitVersion: undefined,
+  installed: true,
+  path: undefined,
+  version: undefined,
+  installedVersion: undefined,
 }
 
 export default createModel({
@@ -57,23 +39,16 @@ export default createModel({
 
       // Clear errors
       state.error = undefined
-
-      // @ts-ignore
-      state[info.name + 'Installed'] = true
-      // @ts-ignore
-      state[info.name + 'Path'] = info.path
-      // @ts-ignore
-      state[info.name + 'Version'] = info.version
+      state.installed = true
+      state.path = info.path
+      state.version = info.version
+      state.installedVersion = info.installedVersion
     },
     notInstalled(state: BinariesState, name: BinaryName) {
       state.installing = false
-
-      // @ts-ignore
-      state[name + 'Installed'] = false
-      // @ts-ignore
-      state[name + 'Path'] = undefined
-      // @ts-ignore
-      state[name + 'Version'] = undefined
+      state.installed = false
+      state.path = undefined
+      state.version = undefined
     },
     installError(state: BinariesState, error: string) {
       state.error = error

--- a/frontend/src/pages/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage/SettingsPage.tsx
@@ -16,11 +16,11 @@ import { Logo } from '../../components/Logo'
 import analytics from '../../helpers/Analytics'
 
 export const SettingsPage = () => {
-  const { os, user, installing, remoteitVersion, preferences } = useSelector((state: ApplicationState) => ({
+  const { os, user, installing, version, preferences } = useSelector((state: ApplicationState) => ({
     os: state.backend.environment.os,
     user: state.auth.user,
     installing: state.binaries.installing,
-    remoteitVersion: state.binaries.remoteitVersion,
+    version: state.binaries.installedVersion || state.binaries.version,
     preferences: state.backend.preferences,
   }))
 
@@ -116,7 +116,7 @@ export const SettingsPage = () => {
           <List>
             <SettingsListItem
               label={installing ? 'Installing...' : 'Re-install command line tools'}
-              subLabel={`Version ${remoteitVersion}`}
+              subLabel={`Version ${version}`}
               disabled={installing}
               icon="terminal"
               onClick={installWarning}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteit-desktop",
-  "version": "2.7.0-alpha.0",
+  "version": "2.7.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteit-desktop",
-  "version": "2.7.0-alpha.0",
+  "version": "2.7.0-alpha.1",
   "private": true,
   "main": "build/index.js",
   "description": "remote.it cross platform desktop application for creating and hosting connections",

--- a/src/TrayMenu.ts
+++ b/src/TrayMenu.ts
@@ -136,7 +136,7 @@ export default class TrayMenu {
   }
 
   private disconnect(connection: IConnection) {
-    headless.pool.stop(connection, false)
+    headless.pool.stop(connection)
   }
 
   private copy(connection: IConnection) {


### PR DESCRIPTION
### Description

CLI Version 1.3.0
Display the actually installed cli version instead of the desired
Fix broken icon display for Other network interface results
Fix parsing of caught cli errors
Add missing -j flag to remove command

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Sign in
2. Go to settings page and see installed version of CLI
3. Update CLI to newer version outside of CLI
4. Close and restart CLI (or wait for hearbeat check )

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/DESK-637>
