### PR TITLE
[DESK-641] Connection errors

### DIFF
--- a/backend/src/Command.ts
+++ b/backend/src/Command.ts
@@ -13,9 +13,9 @@ export default class Command {
   admin: boolean = false
   quiet: boolean = false
 
-  onError: (error: Error) => void = () => {}
+  onError: ErrorCallback = () => {}
 
-  constructor(options: { command?: string; admin?: boolean; onError?: (error: Error) => void; quiet?: boolean }) {
+  constructor(options: { command?: string; admin?: boolean; onError?: ErrorCallback; quiet?: boolean }) {
     if (options.command) this.commands = [options.command]
     options.command = undefined
     Object.assign(this, options)

--- a/backend/src/Connection.ts
+++ b/backend/src/Connection.ts
@@ -30,7 +30,7 @@ export default class Connection extends EventEmitter {
   ) {
     this.params = { host, restriction, failover, ...connection }
     Logger.info('SET CONNECTION', { params: this.params })
-    if (setCLI) await cli.setConnection(this.params)
+    if (setCLI) await cli.setConnection(this.params, this.error)
   }
 
   async start() {
@@ -41,7 +41,7 @@ export default class Connection extends EventEmitter {
 
     this.params.active = true
     this.params.connecting = false
-    await cli.addConnection(this.params)
+    await cli.addConnection(this.params, this.error)
 
     EventBus.emit(Connection.EVENTS.connected, { connection: this.params, raw: 'Connected' })
   }
@@ -52,11 +52,16 @@ export default class Connection extends EventEmitter {
     this.params.active = false
     this.params.endTime = Date.now()
 
-    await cli.setConnection(this.params)
+    await cli.setConnection(this.params, this.error)
     EventBus.emit(Connection.EVENTS.disconnected, { connection: this.params } as ConnectionMessage)
   }
 
   async forget() {
-    await cli.removeConnection(this.params)
+    await cli.removeConnection(this.params, this.error)
+  }
+
+  error = (e: Error) => {
+    this.params.error = { message: e.message }
+    this.stop()
   }
 }

--- a/backend/src/ConnectionPool.ts
+++ b/backend/src/ConnectionPool.ts
@@ -51,9 +51,8 @@ export default class ConnectionPool {
       if (
         !connection ||
         connection.startTime !== c.startTime ||
-        connection.active !== c.active ||
-        connection.failover !== c.failover ||
-        connection.autoStart !== c.autoStart
+        connection.endTime !== c.endTime ||
+        connection.active !== c.active
       ) {
         await this.set({ ...connection, ...c })
       }

--- a/common/types.d.ts
+++ b/common/types.d.ts
@@ -255,6 +255,8 @@ declare global {
 
   type ISimpleError = { code?: number; message: string }
 
+  type ErrorCallback = (error: Error) => void
+
   type ILog = { [id: string]: string[] }
 
   type IInterface = { [key: string]: any }


### PR DESCRIPTION
### Description

<!-- Describe, at a high level, what changes you made and why -->
So that connection errors affect the connection object and the errors stay with the specific connection instead of just in the global messaging.

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Sign in
2. Go to a bad connection and trigger a connection error ... ?
3. You should see the error in the main messaging but also see the connection go back offline and see the warning indicator witht the connection error message available.

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/DESK-641>
