### PR TITLE
[DESK-584] Tray menu grouping

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteit-headless",
-  "version": "2.7.0-alpha.3",
+  "version": "2.7.0-alpha.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "remoteit-headless",
-    "version": "2.7.0-alpha.3",
+    "version": "2.7.0-alpha.4",
     "private": true,
     "main": "build/index.js",
     "scripts": {

--- a/backend/src/CLI.ts
+++ b/backend/src/CLI.ts
@@ -171,7 +171,7 @@ export default class CLI {
     await this.exec({ cmds: [strings.serviceUninstall(), strings.serviceInstall()], admin: true })
   }
 
-  async install() {
+  async toolsInstall() {
     await this.exec({ cmds: [strings.toolsInstall()], admin: true })
   }
 

--- a/backend/src/Connection.ts
+++ b/backend/src/Connection.ts
@@ -40,6 +40,7 @@ export default class Connection extends EventEmitter {
 
     this.params.active = true
     this.params.connecting = false
+    this.params.error = undefined
     await cli.addConnection(this.params, this.error)
     EventBus.emit(Connection.EVENTS.connected, { connection: this.params, raw: 'Connected' })
   }

--- a/backend/src/Controller.ts
+++ b/backend/src/Controller.ts
@@ -56,9 +56,10 @@ class Controller {
     socket.on('user/sign-out-complete', this.signOutComplete)
     socket.on('user/clear-all', user.clearAll)
     socket.on('user/quit', this.quit)
-    socket.on('service/connect', this.connect)
-    socket.on('service/disconnect', this.disconnect)
-    socket.on('service/forget', this.forget)
+    socket.on('service/connect', this.pool.start)
+    socket.on('service/disconnect', this.pool.stop)
+    socket.on('service/clear-recent', this.pool.forgetRecent)
+    socket.on('service/forget', this.pool.forget)
     socket.on('binaries/install', this.installBinaries)
     socket.on('init', this.syncBackend)
     socket.on('connection', this.connection)
@@ -69,7 +70,7 @@ class Controller {
     socket.on('oobCheck', this.oobCheck)
     socket.on('interfaces', this.interfaces)
     socket.on('freePort', this.freePort)
-    socket.on('preferences', this.preferences)
+    socket.on('preferences', preferences.set)
     socket.on('restart', this.restart)
     socket.on('uninstall', this.uninstall)
 
@@ -126,8 +127,6 @@ class Controller {
     this.io.emit('nextFreePort', this.pool.freePort)
   }
 
-  preferences = preferences.set
-
   syncBackend = async () => {
     this.io.emit('oob', { oobAvailable: lan.oobAvailable, oobActive: lan.oobActive })
     this.io.emit('targets', cli.data.targets)
@@ -143,21 +142,6 @@ class Controller {
 
   connection = async (connection: IConnection) => {
     await this.pool.set(connection, true)
-  }
-
-  connect = async (connection: IConnection) => {
-    Logger.info('CONNECT', { id: connection.id })
-    await this.pool.start(connection)
-  }
-
-  disconnect = async (connection: IConnection) => {
-    Logger.info('DISCONNECT', { id: connection.id })
-    await this.pool.stop(connection)
-  }
-
-  forget = async (connection: IConnection) => {
-    Logger.info('FORGET', { id: connection.id })
-    await this.pool.forget(connection)
   }
 
   quit = () => {

--- a/backend/src/electronInterface.ts
+++ b/backend/src/electronInterface.ts
@@ -1,4 +1,5 @@
 export const EVENTS = {
+  clearRecent: 'service/clear-recent',
   forget: 'tray/forget',
   ready: 'app/ready',
   open: 'app/open',

--- a/common/types.d.ts
+++ b/common/types.d.ts
@@ -25,6 +25,7 @@ declare global {
     | 'service/disconnect'
     | 'service/forget'
     | 'service/restart'
+    | 'service/clear-recent'
 
     // App/settings
     | 'app/open-on-login'

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteit-desktop-frontend",
-  "version": "2.7.0-alpha.3",
+  "version": "2.7.0-alpha.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteit-desktop-frontend",
-  "version": "2.7.0-alpha.3",
+  "version": "2.7.0-alpha.4",
   "private": true,
   "main": "src/server/initialize.js",
   "scripts": {

--- a/frontend/src/buttons/ForgetButton/ForgetButton.tsx
+++ b/frontend/src/buttons/ForgetButton/ForgetButton.tsx
@@ -8,22 +8,23 @@ import { Icon } from '../../components/Icon'
 type Props = {
   connection?: IConnection
   disabled?: boolean
+  all?: boolean
 }
 
-export const ForgetButton: React.FC<Props> = ({ disabled = false, connection }) => {
+export const ForgetButton: React.FC<Props> = ({ disabled = false, connection, all }) => {
   const history = useHistory()
   const location = useLocation()
 
-  if (!connection || connection.active) return null
+  if (!all && (!connection || connection.active)) return null
 
   const forget = () => {
-    emit('service/forget', connection)
+    emit(all ? 'service/clear-recent' : 'service/forget', connection)
     const menu = location.pathname.match(REGEX_FIRST_PATH)
     if (menu && menu[0] === '/connections') history.push('/connections')
   }
 
   return (
-    <Tooltip title="Clear this connection">
+    <Tooltip title={all ? 'Clear connections' : 'Clear this connection'}>
       <IconButton disabled={disabled} onClick={forget}>
         <Icon name="times" size="md" fixedWidth />
       </IconButton>

--- a/frontend/src/components/ConnectionsList/ConnectionsList.tsx
+++ b/frontend/src/components/ConnectionsList/ConnectionsList.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
-import { Body } from '../../components/Body'
+import { Body } from '../Body'
+import { Title } from '../Title'
 import { useHistory } from 'react-router-dom'
 import { makeStyles } from '@material-ui/core/styles'
+import { ForgetButton } from '../../buttons/ForgetButton'
 import { ServiceListItem } from '../ServiceListItem'
 import { Typography, Link, List, Divider } from '@material-ui/core'
 import styles from '../../styling'
@@ -41,7 +43,12 @@ export const ConnectionsList: React.FC<Props> = ({ connections, services }) => {
         <ServiceListItem key={c.id || 0} connection={c} service={services.find(s => s.id === c.id)} />
       ))}
       {!!recent.length && !!connected.length && <Divider />}
-      {!!recent.length && <Typography variant="subtitle1">Recent</Typography>}
+      {!!recent.length && (
+        <Typography variant="subtitle1">
+          <Title>Recent</Title>
+          <ForgetButton all />
+        </Typography>
+      )}
       {recent.map(c => (
         <ServiceListItem key={c.id || 0} connection={c} service={services.find(s => s.id === c.id)} />
       ))}

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -16,7 +16,7 @@ export const Header: React.FC = () => {
 
   return (
     <div className={css.header}>
-      <Typography>
+      <Typography variant="h4">
         {device.name ? device.name : 'remote.it'} {guest && <span className={css.guest}>- Guest</span>}
       </Typography>
     </div>
@@ -34,17 +34,17 @@ const useStyles = makeStyles({
     minHeight: 40,
     '-webkit-user-select': 'none',
     '-webkit-app-region': 'drag',
-    '& img': {
-      width: 120,
-    },
+    '& img': { width: 120 },
     '& .MuiButtonBase-root': {
       position: 'absolute',
       left: styles.spacing.xs,
     },
     '& .MuiTypography-root': {
-      color: styles.colors.grayDarker,
+      color: styles.colors.grayDark,
       textAlign: 'center',
+      fontWeight: 100,
       width: '100%',
+      margin: 0,
     },
   },
   guest: {

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -16,7 +16,7 @@ export const Header: React.FC = () => {
 
   return (
     <div className={css.header}>
-      <Typography variant="h4">
+      <Typography variant="body2">
         {device.name ? device.name : 'remote.it'} {guest && <span className={css.guest}>- Guest</span>}
       </Typography>
     </div>
@@ -42,7 +42,6 @@ const useStyles = makeStyles({
     '& .MuiTypography-root': {
       color: styles.colors.grayDark,
       textAlign: 'center',
-      fontWeight: 100,
       width: '100%',
       margin: 0,
     },

--- a/frontend/src/components/Router/Router.tsx
+++ b/frontend/src/components/Router/Router.tsx
@@ -27,13 +27,13 @@ export const Router: React.FC = () => {
     uninstalling: state.ui.uninstalling,
     os: state.backend.environment.os,
   }))
-  const { guest, notElevated } = usePermissions()
+  const { guest } = usePermissions()
   const history = useHistory()
   const registered = !!device.uid
 
   let setupLocation = 'setupDevice'
   if (registered) setupLocation = 'setupServices'
-  if (guest || notElevated) setupLocation = 'setupView'
+  if (guest) setupLocation = 'setupView'
 
   useEffect(() => {
     if (dataReady) {

--- a/frontend/src/components/ServiceName/ServiceName.tsx
+++ b/frontend/src/components/ServiceName/ServiceName.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { useLocation } from 'react-router-dom'
-import { makeStyles } from '@material-ui/core/styles'
-import { REGEX_FIRST_PATH } from '../../shared/constants'
 import { Icon } from '../Icon'
-import { colors, spacing } from '../../styling'
+import { Title } from '../Title'
+import { useLocation } from 'react-router-dom'
+import { REGEX_FIRST_PATH } from '../../shared/constants'
+import { colors } from '../../styling'
 
 type Props = {
   connection?: IConnection
@@ -14,7 +14,6 @@ type Props = {
 
 export const ServiceName: React.FC<Props> = ({ connection, service, shared }) => {
   const location = useLocation()
-  const css = useStyles()
 
   const menu = location.pathname.match(REGEX_FIRST_PATH)
   const name = menu && menu[0] === '/connections' ? connection && connection.name : service && service.name
@@ -25,20 +24,13 @@ export const ServiceName: React.FC<Props> = ({ connection, service, shared }) =>
   if (connection && connection.active) color = undefined
 
   return (
-    <span className={css.title} style={{ color }}>
+    <Title color={color}>
       {!service && !connection ? 'No device found' : name}
       {shared && (
         <sup>
           <Icon name="user-friends" size="xxxs" type="solid" fixedWidth />
         </sup>
       )}
-    </span>
+    </Title>
   )
 }
-
-const useStyles = makeStyles({
-  title: {
-    flexGrow: 1,
-    '& sup': { marginLeft: spacing.xs },
-  },
-})

--- a/frontend/src/components/Title/Title.tsx
+++ b/frontend/src/components/Title/Title.tsx
@@ -1,11 +1,16 @@
 import React from 'react'
 import { makeStyles } from '@material-ui/core'
+import { spacing } from '../../styling'
 
-export const Title: React.FC<{ primary: string }> = ({ primary }) => {
+export const Title: React.FC<{ color?: string }> = ({ children, color }) => {
   const css = useStyles()
-  return <span className={css.title}>{primary}</span>
+  return (
+    <span className={css.title} style={{ color }}>
+      {children}
+    </span>
+  )
 }
 
 const useStyles = makeStyles({
-  title: { flexGrow: 1 },
+  title: { flexGrow: 1, '& sup': { marginLeft: spacing.xs } },
 })

--- a/frontend/src/pages/LogPage/LogPage.tsx
+++ b/frontend/src/pages/LogPage/LogPage.tsx
@@ -29,7 +29,7 @@ export const LogPage: React.FC = () => {
           <Breadcrumbs />
           <Typography variant="h1">
             <Icon name="stream" size="lg" />
-            <Title primary="Raw Connection Log" />
+            <Title>Raw Connection Log</Title>
             <Tooltip title="Clear log">
               <IconButton onClick={() => dispatch.logs.clear(id)}>
                 <Icon name="trash-alt" size="md" fixedWidth />

--- a/frontend/src/pages/UsersPage/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage/UsersPage.tsx
@@ -28,7 +28,7 @@ export const UsersPage: React.FC = () => {
           <Breadcrumbs />
           <Typography variant="h1">
             <Icon name="user-friends" size="lg" />
-            <Title primary="Users" />
+            <Title>Users</Title>
           </Typography>
         </>
       }

--- a/frontend/src/styling/theme.ts
+++ b/frontend/src/styling/theme.ts
@@ -2,6 +2,7 @@ import { colors, spacing, fontSizes } from './'
 import { createMuiTheme } from '@material-ui/core'
 
 const gutters = 32
+const titlePadding = `${spacing.xxs}px ${gutters - 8}px ${spacing.xxs}px ${gutters}px`
 export default createMuiTheme({
   palette: {
     primary: { main: colors.primary },
@@ -90,7 +91,7 @@ export default createMuiTheme({
         fontWeight: 400,
         display: 'flex',
         alignItems: 'center',
-        padding: `${spacing.xxs}px ${gutters}px`,
+        padding: titlePadding,
         borderBottom: `1px solid ${colors.grayLighter}`,
         minHeight: 50,
         '& span + span': { marginLeft: spacing.lg },
@@ -109,9 +110,11 @@ export default createMuiTheme({
       subtitle1: {
         fontSize: fontSizes.sm,
         fontFamily: 'Roboto Mono',
-        color: colors.gray,
-        padding: `${spacing.lg}px ${spacing.sm}px 0 ${gutters}px`,
-        marginLeft: spacing.xxs,
+        color: colors.grayDark,
+        display: 'flex',
+        alignItems: 'flex-end',
+        minHeight: 50,
+        padding: titlePadding,
         textTransform: 'uppercase',
         letterSpacing: 3,
         fontWeight: 500,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteit-desktop",
-  "version": "2.7.0-alpha.3",
+  "version": "2.7.0-alpha.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteit-desktop",
-  "version": "2.7.0-alpha.3",
+  "version": "2.7.0-alpha.4",
   "private": true,
   "main": "build/index.js",
   "description": "remote.it cross platform desktop application for creating and hosting connections",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "build/index.js",
   "description": "remote.it cross platform desktop application for creating and hosting connections",
   "scripts": {
-    "build": "cross-env NODE_ENV=production run-s clean compile copy-* build-*",
+    "build": "cross-env NODE_ENV=production run-s clean build-backend compile copy-* build-electron",
     "build-backend": "cd backend && npm run build",
     "build-electron": "cross-env electron-builder -$PLATFORMS",
     "clean": "rimraf build/* dist/*",

--- a/src/ElectronApp.ts
+++ b/src/ElectronApp.ts
@@ -132,7 +132,7 @@ export default class ElectronApp {
     new TrayMenu(this.tray)
   }
 
-  private openWindow = (openDevTools?: boolean) => {
+  private openWindow = (location?: string, openDevTools?: boolean) => {
     if (!this.window || !this.tray) return
     d('Showing window')
 
@@ -143,6 +143,7 @@ export default class ElectronApp {
 
     this.window.show()
 
+    if (location) this.window.webContents.executeJavaScript(`window.location.hash="#/${location}"`)
     if (openDevTools) this.window.webContents.openDevTools({ mode: 'detach' })
   }
 


### PR DESCRIPTION
### Description

<!-- Describe, at a high level, what changes you made and why -->
System tray menu improvements to limit number of connections or recent connections to 10 and provide a clear recent menu.

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Sign in
2. Add 11 or more different connections
3. Look at the system tray menu. You should see up to 10 connections and recent connections. 
4. If more than 10 connections you should see a menu item that says "and X more..." 
5. If you click the more menu it should open the connections page in desktop
6. Clicking the X on the connections page to the right of recent should clear the recent connections
7. The same clear recent function is also available on the system tray menu.

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/DESK-584>
