### PR TITLE
[DESK-680][DESK-682] show conn type

### DIFF
--- a/backend/src/CLI.ts
+++ b/backend/src/CLI.ts
@@ -29,7 +29,12 @@ type IExec = {
   onError?: ErrorCallback
 }
 
-type IConnectionStatus = { id?: string; connectionState?: 'offline' | 'connecting' | 'connected' }
+type IConnectionStatus = {
+  id?: string
+  connectionState?: 'offline' | 'connecting' | 'connected'
+  isFailover?: boolean
+  isP2P?: boolean
+}
 
 export default class CLI {
   data: IData = {
@@ -132,6 +137,7 @@ export default class CLI {
       if (status) {
         c.active = status.connectionState === 'connected' || status.connectionState === 'connecting'
         c.connecting = status.connectionState === 'connecting'
+        c.isP2P = status.isP2P
         d('UPDATE STATUS', { c, status: status.connectionState })
       }
       return c

--- a/backend/src/binaryInstaller.test.ts
+++ b/backend/src/binaryInstaller.test.ts
@@ -40,13 +40,11 @@ describe('backend/binaryInstaller', () => {
       expect(commandSpy).toBeCalledWith('mv undefined ../jest/bin/remoteit')
       expect(commandSpy).toBeCalledWith('chmod 755 ../jest/bin/remoteit')
       expect(commandSpy).toBeCalledWith('"../jest/bin/remoteit" -j tools install --update')
-      expect(commandSpy).toBeCalledWith('"../jest/bin/remoteit" -j service uninstall')
-      expect(commandSpy).toBeCalledWith('"../jest/bin/remoteit" -j service install')
       expect(commandSpy).toBeCalledWith(
         `"../jest/bin/remoteit" -j signin --user ${user.username} --authhash ${user.authHash}`
       )
 
-      expect(commandSpy).toBeCalledTimes(7)
+      expect(commandSpy).toBeCalledTimes(5)
       expect(downloadSpy).toBeCalledTimes(1)
     })
 
@@ -59,12 +57,11 @@ describe('backend/binaryInstaller', () => {
       expect(commandSpy).toBeCalledWith('move /y "undefined" "../jest/bin/remoteit.exe"')
       expect(commandSpy).toBeCalledWith('icacls "../jest/bin/remoteit.exe" /T /C /Q /grant "*S-1-5-32-545:RX"')
       expect(commandSpy).toBeCalledWith('"../jest/bin/remoteit.exe" -j tools install --update')
-      expect(commandSpy).toBeCalledWith('"../jest/bin/remoteit.exe" -j service uninstall')
       expect(commandSpy).toBeCalledWith(
         `"../jest/bin/remoteit.exe" -j signin --user ${user.username} --authhash ${user.authHash}`
       )
 
-      expect(commandSpy).toBeCalledTimes(7)
+      expect(commandSpy).toBeCalledTimes(5)
       expect(downloadSpy).toBeCalledTimes(1)
     })
   })

--- a/backend/src/binaryInstaller.ts
+++ b/backend/src/binaryInstaller.ts
@@ -61,8 +61,6 @@ class BinaryInstaller {
       }
 
       commands.push(`"${installer.binaryPath()}" ${strings.toolsInstall()}`)
-      commands.push(`"${installer.binaryPath()}" ${strings.serviceUninstall()}`)
-      commands.push(`"${installer.binaryPath()}" ${strings.serviceInstall()}`)
       commands.push(`"${installer.binaryPath()}" ${strings.signIn()}`)
 
       await commands.exec()

--- a/backend/src/constants.ts
+++ b/backend/src/constants.ts
@@ -12,7 +12,7 @@ export const AIRBRAKE_PROJECT_ID = 223457
 export const AIRBRAKE_PROJECT_KEY = process.env.AIRBRAKE_PROJECT_KEY || 'e1376551dbe5b1326f98edd78b6247ba'
 
 // CLI
-export const CLI_VERSION = '1.4.7'
+export const CLI_VERSION = '1.4.8'
 export const CLI_DOWNLOAD: 'AWS' | 'GitHub' = 'AWS' // AWS or GitHub
 
 // CLI product tracking codes

--- a/common/types.d.ts
+++ b/common/types.d.ts
@@ -119,7 +119,8 @@ declare global {
     host?: ipAddress // Bind address
     typeID?: number // service type ID
     restriction?: ipAddress // Restriction IP address
-    autoStart?: boolean
+    autoStart?: boolean // auto retry connect if closed
+    isP2P?: boolean // if the connection was made with peer to peer vs failover
     failover?: boolean // allow proxy failover
     connecting?: boolean
     username?: string // support for launching where username could be saved

--- a/frontend/src/components/ServiceConnected/ServiceConnected.tsx
+++ b/frontend/src/components/ServiceConnected/ServiceConnected.tsx
@@ -24,6 +24,15 @@ export const ServiceConnected: React.FC<Props> = ({ connection, service }) => {
           data={[
             { label: 'Connection URL', value: connection && hostName(connection) },
             { label: 'Duration', value: connection && <Duration startTime={connection.startTime} /> },
+            {
+              label: 'Type',
+              value:
+                connection?.isP2P === undefined
+                  ? 'None'
+                  : connection?.isP2P === true
+                  ? 'Peer to peer'
+                  : 'Proxy failover',
+            },
           ]}
         />
         <div>

--- a/uninstaller.nsh
+++ b/uninstaller.nsh
@@ -1,5 +1,5 @@
 !macro customUnInstall
-    MessageBox MB_YESNO "Would you like to unregister your device?" IDNO false IDYES true
+    MessageBox MB_YESNO|MB_DEFBUTTON2 "Would you like to unregister your device?" IDYES true IDNO false
     true:
         ExecWait '"C:\Program Files\remoteit-bin\remoteit.exe" -j uninstall --yes'
         RMDir /r "$APPDATA\remoteit"
@@ -13,5 +13,5 @@
     RMDir /r "C:\Program Files\remoteit-bin"
     RMDir /r "$PROFILE\AppData\Local\remoteit"
     RMDir /r "$INSTDIR"
-    MessageBox MB_OK "remote.it was successfully removed!" 
+    MessageBox MB_OK "remote.it was successfully uninstalled!"
 !macroend

--- a/uninstaller.nsh
+++ b/uninstaller.nsh
@@ -1,5 +1,5 @@
 !macro customUnInstall
-    MessageBox MB_YESNO "Would you like to unregistered your device?" IDYES true IDNO false
+    MessageBox MB_YESNO "Would you like to unregister your device?" IDNO false IDYES true
     true:
         ExecWait '"C:\Program Files\remoteit-bin\remoteit.exe" -j uninstall --yes'
         RMDir /r "$APPDATA\remoteit"


### PR DESCRIPTION
### Description

<!-- Describe, at a high level, what changes you made and why -->
Show the connection type now available in CLI
Switch default of deregister command to no.

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Sign in
2. Connect to a device
3. View the service detail page and see the connection type ie: "peer to peer"

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/DESK-680>
<https://remoteit.atlassian.net/browse/DESK-682>
