### PR TITLE
[DESK-695] Hardening of connection initialization

### DIFF
--- a/backend/src/ConnectionPool.ts
+++ b/backend/src/ConnectionPool.ts
@@ -46,7 +46,7 @@ export default class ConnectionPool {
 
   // Sync with CLI
   check = async () => {
-    if (!remoteitInstaller.isInstalled()) return
+    if (!remoteitInstaller.isCliCurrent()) return
 
     await cli.updateConnectionStatus()
 


### PR DESCRIPTION
### Description

<!-- Describe, at a high level, what changes you made and why -->
Hardening of connection initialization

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Start with active connections in an older version of Desktop
2. Update desktop
3. On update you should not see errors where connections are trying to start before the CLI installation is complete

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/DESK-695>
