### PR TITLE
DESK-802 p2p setting

### DIFF
--- a/frontend/src/components/ServiceForm/ServiceForm.tsx
+++ b/frontend/src/components/ServiceForm/ServiceForm.tsx
@@ -38,10 +38,11 @@ export const ServiceForm: React.FC<Props> = ({
   )
   const disabled = setupBusy || deleting
   const [error, setError] = useState<string>()
-  const [form, setForm] = useState<ITarget & IService['attributes']>({ ...target, name, route: route || routingLock })
+  const [form, setForm] = useState<ITarget & IService['attributes']>({ ...target, name, route: routingLock || route })
   const appType = findType(applicationTypes, form.type)
   const css = useStyles()
-
+  console.log('ROUTING LOCK', routingLock)
+  console.log('FORM', form)
   return (
     <form onSubmit={() => onSubmit({ ...form, port: form.port || 1, name: form.name || appType.description })}>
       <List>
@@ -135,7 +136,7 @@ export const ServiceForm: React.FC<Props> = ({
           <TextField
             select
             label="Routing"
-            value={routingLock || form.route}
+            value={form.route}
             disabled={!!routingLock || disabled}
             variant="filled"
             onChange={event => {


### PR DESCRIPTION
### Description

<!-- Describe, at a high level, what changes you made and why -->

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Sign in to AWS ami
2. Go to add new service
3. Click save
4. You should see the service connection setting be locked to p2p only

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/DESK-802 >
