### PR TITLE
DESK-863 Timeout handling

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -25,8 +25,7 @@ class Server {
   private app: Express
 
   EVENTS = {
-    connection: 'server/connection',
-    authenticated: 'server/authenticated',
+    authenticated: 'authenticated',
   }
 
   constructor() {
@@ -84,7 +83,7 @@ class Server {
       authenticate: this.authenticate,
       postAuthenticate: this.postAuthenticate,
       disconnect: this.disconnect,
-      timeout: 10000,
+      timeout: 20000,
     }
 
     socketioAuth(this.io, authOptions)
@@ -142,8 +141,8 @@ class Server {
   }
 
   disconnect = (socket: SocketIO.Socket) => {
-    socket.removeAllListeners()
     Logger.info('SERVER DISCONNECT')
+    socket.removeAllListeners()
   }
 }
 

--- a/frontend/src/models/auth.ts
+++ b/frontend/src/models/auth.ts
@@ -109,6 +109,12 @@ export default createModel({
         dispatch.applicationTypes.fetch()
       }
     },
+    async disconnect(_: void, rootState: any) {
+      if (!rootState.auth.backendAuthenticated) {
+        dispatch.auth.backendSignInError('Sign in failed')
+      }
+      dispatch.ui.set({ connected: false })
+    },
     async signInError(error: string) {
       dispatch.auth.setError(error)
       //send message to backend to sign out

--- a/frontend/src/services/Controller.ts
+++ b/frontend/src/services/Controller.ts
@@ -86,11 +86,9 @@ function getEventHandlers() {
 
     unauthorized: (error: Error) => auth.backendSignInError(error.message),
 
-    'server/authenticated': () => auth.authenticated(),
+    authenticated: () => auth.authenticated(),
 
-    disconnect: () => {
-      ui.set({ connected: false })
-    },
+    disconnect: () => auth.disconnect(),
 
     connect_error: () => {
       backend.set({ error: true })


### PR DESCRIPTION
### Description

<!-- Describe, at a high level, what changes you made and why -->
When auth times out on the backend the connection gets dropped and the desktop seems locked up.
We need to handle this scenario and return the user back to the login screen to re-try to auth.

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Sign in on a timing out connection
2. You should see the sign in screen again upon failure.

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/DESK-863>
