### PR TITLE
FIND-10 /system requests by find.remote.it should return device.uid

### DIFF
--- a/backend/src/systemInfo.ts
+++ b/backend/src/systemInfo.ts
@@ -7,11 +7,11 @@ export default async function systemInfo() {
   await lan.getInterfaces()
 
   return {
+    id: cli.data.device.uid,
     os: environment.simpleOS,
     arch: os.arch(),
     platform: os.platform(),
     privateIP: lan.privateIP,
-    name: cli.data.device.name,
     interfaces: lan.interfaces,
   }
 }


### PR DESCRIPTION
### Description

/system requests by find.remote.it should return device.uid instead of device.name because it's no longer available in config.json

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/FIND-10>
