### PR TITLE
Removing maxWidth

### DIFF
--- a/src/ElectronApp.ts
+++ b/src/ElectronApp.ts
@@ -113,7 +113,6 @@ export default class ElectronApp {
     this.window = new electron.BrowserWindow({
       width: 800,
       height: 700,
-      maxWidth: 1000,
       minWidth: 525,
       minHeight: 325,
       icon: path.join(__dirname, 'images/icon-64x64.png'),


### PR DESCRIPTION
### Description
I have some issues on my computer, and it's awful to have remote.it running in "full screen" while it only occupies part of my screen.

<!-- Describe, at a high level, what changes you made and why -->

### Checklist

<!-- Please make sure all the boxes below are checked or removed if not relevant -->

- [x] This PR only contains one isolated change (bug fix, feature, etc)
- [x] I have manually reviewed this PR to make sure only the files I intended to change were changed and nothing else

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Start Remote.it
2. Press Full Screen Button
3. You should have the app in full screen

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->
Nothing 🙂