### PR TITLE
DESK-949 Fixing default port assignment

### DIFF
--- a/frontend/src/components/InlineTemplateSetting/InlineTemplateSetting.tsx
+++ b/frontend/src/components/InlineTemplateSetting/InlineTemplateSetting.tsx
@@ -12,8 +12,7 @@ import { Icon } from '../Icon'
 type Props = { service: IService; connection?: IConnection; context: Application['context'] }
 
 export const InlineTemplateSetting: React.FC<Props> = ({ service, connection, context }) => {
-  const freePort = useSelector((state: ApplicationState) => state.backend.freePort)
-  if (!connection) connection = newConnection(service, freePort)
+  if (!connection) connection = newConnection(service)
   const app = useApplication(context, service, connection)
 
   return (

--- a/frontend/src/components/PortSetting/PortSetting.tsx
+++ b/frontend/src/components/PortSetting/PortSetting.tsx
@@ -7,15 +7,16 @@ import { ApplicationState } from '../../store'
 import { newConnection, setConnection } from '../../helpers/connectionHelper'
 
 export const PortSetting: React.FC<{ service: IService; connection?: IConnection }> = ({ service, connection }) => {
-  const currentPort = connection?.port || service.attributes?.defaultPort
-  const freePort = useSelector((state: ApplicationState) => state.backend.freePort)
+  const defaultPort = useSelector(
+    (state: ApplicationState) => service.attributes?.defaultPort || state.backend.freePort
+  )
 
   useEffect(() => {
-    if (!connection || !freePort || freePort !== connection.port) emit('freePort', connection)
-  }, [freePort, connection])
+    if (!connection || !connection.port) emit('freePort', connection)
+  }, [connection])
 
   if (!service) return null
-  if (!connection) connection = newConnection(service, freePort)
+  if (!connection) connection = newConnection(service)
 
   const disabled = connection.active || connection.connecting
   const save = (port?: number) =>
@@ -27,11 +28,11 @@ export const PortSetting: React.FC<{ service: IService; connection?: IConnection
 
   return (
     <InlineTextFieldSetting
-      value={currentPort || freePort}
+      value={connection.port}
       label="Port"
       disabled={disabled}
       filter={REGEX_PORT_SAFE}
-      resetValue={freePort}
+      resetValue={defaultPort}
       onSave={port => save(+port)}
     />
   )

--- a/frontend/src/components/ServiceForm/ServiceForm.tsx
+++ b/frontend/src/components/ServiceForm/ServiceForm.tsx
@@ -247,6 +247,7 @@ export const ServiceForm: React.FC<Props> = ({
             ...DEFAULT_CONNECTION,
             ...form.attributes,
             typeID: form.type,
+            port: form.attributes.defaultPort,
           }}
           disabled={disabled}
           attributes={form.attributes}

--- a/frontend/src/helpers/connectionHelper.ts
+++ b/frontend/src/helpers/connectionHelper.ts
@@ -27,10 +27,11 @@ export function connectionName(service?: IService, device?: IDevice) {
   return `${attributeName(device)} - ${attributeName(service)}`
 }
 
-export function newConnection(service?: IService | null, port?: number) {
+export function newConnection(service?: IService | null) {
   const state = store.getState()
   const accountId = getActiveAccountId(state)
   const user = [...state.accounts.member, state.auth.user].find(u => u?.id === accountId)
+  const port = service?.attributes.defaultPort || state.backend.freePort
 
   let connection: IConnection = {
     ...DEFAULT_CONNECTION,

--- a/frontend/src/pages/LanSharePage/LanSharePage.tsx
+++ b/frontend/src/pages/LanSharePage/LanSharePage.tsx
@@ -26,7 +26,7 @@ export const LanSharePage: React.FC = () => {
     return {
       service,
       privateIP: state.backend.environment.privateIP,
-      connection: connection || newConnection(service, state.backend.freePort),
+      connection: connection || newConnection(service),
     }
   })
 


### PR DESCRIPTION
### Description

<!-- Describe, at a high level, what changes you made and why -->

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Sign in
2. Go to a device you own and go to the edit service screen
3. Click the default port field and set a default
4. You should see the port change in the url previews 
5. You should return to the connection page and see the default values
6. When you connect it should use the defaults.

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/DESK-949>
