### PR TITLE
[DESK-939] Installer should not move config on init

### DIFF
--- a/installer.nsh
+++ b/installer.nsh
@@ -24,7 +24,7 @@
     CopyFiles /SILENT "$APPDATA\remoteit\config.json" "${REMOTEIT_BACKUP}\config-${PKGVERSION}.json"
     CopyFiles /SILENT "$PROFILE\AppData\Local\remoteit\connections" "${REMOTEIT_BACKUP}\connections-${PKGVERSION}"
 
-    ; MessageBox MB_OK "Init: moved files" 
+    ; MessageBox MB_OK "Init: copied files" 
 !macroend
 
 !macro customInstall
@@ -66,12 +66,6 @@
     Pop $0
     Pop $1
     FileWrite $installLog "$ps_command     [$0]  $1$\r$\n"
-
-    ; restore config from backup
-    ; MessageBox MB_OK "Install: will restore files"
-    CopyFiles /SILENT "${REMOTEIT_BACKUP}\config-${PKGVERSION}.json" "$APPDATA\remoteit\config.json"
-    CopyFiles /SILENT "${REMOTEIT_BACKUP}\connections-${PKGVERSION}" "$PROFILE\AppData\Local\remoteit\connections"
-    FileWrite $installLog "Restore config files $\r$\n"
 
     StrCpy $ps_command 'powershell "& " "$\'"$path_\remoteit.exe$\'" -j agent install'
     nsExec::ExecToStack /OEM $ps_command

--- a/installer.nsh
+++ b/installer.nsh
@@ -13,9 +13,6 @@
         StrCpy $path_i '$INSTDIR\resources\x86'
     ${EndIf}
 
-    ; stop the agent
-    nsExec::ExecToStack /OEM 'powershell "& " "$\'"$path_i\remoteit.exe$\'" -j agent stop'
-
     ; create backup directory if doesn't exist
     CreateDirectory "${REMOTEIT_BACKUP}"
 
@@ -23,9 +20,9 @@
     Delete "${REMOTEIT_BACKUP}\config-${PKGVERSION}.json"
     RMDir /r  "${REMOTEIT_BACKUP}\connections-${PKGVERSION}"
 
-    ; move the config file and connections to backup location ONLY MOVES IF EMPTY (protect against 2.9.2 uninstall bug)
-    Rename "$APPDATA\remoteit\config.json" "${REMOTEIT_BACKUP}\config-${PKGVERSION}.json"
-    Rename "$PROFILE\AppData\Local\remoteit\connections" "${REMOTEIT_BACKUP}\connections-${PKGVERSION}"
+    ; copy the config file and connections to backup location ONLY MOVES IF EMPTY (protect against 2.9.2 uninstall bug)
+    CopyFiles /SILENT "$APPDATA\remoteit\config.json" "${REMOTEIT_BACKUP}\config-${PKGVERSION}.json"
+    CopyFiles /SILENT "$PROFILE\AppData\Local\remoteit\connections" "${REMOTEIT_BACKUP}\connections-${PKGVERSION}"
 
     ; MessageBox MB_OK "Init: moved files" 
 !macroend


### PR DESCRIPTION
### Description

<!-- Describe, at a high level, what changes you made and why -->

### Checklist

<!-- Please make sure all the boxes below are checked or removed if not relevant -->

- [ ] Pull Request title is in the format `[PROJ-12345] Some useful description here...`
- [ ] The git branch is in the format `PROJ-12345-some-useful-description-here`
- [x] I have added one or more reviewers
- [x] I have added/updated tests for any code changes
- [ ] This PR only contains one isolated change (bug fix, feature, etc)
- [ ] Translation strings added/updated for all user-visible text
- [x] I have manually reviewed this PR to make sure only the files I intended to change were changed and nothing else
- [x] I have notified reviewers on Slack by @ mentioning them in the `#desktop`channel
- [x] I have moved the Jira ticket into `Resolved` state and made a note in the ticket with a link to this PR

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

Check the clean installation and update installation.

#### In case of update installation
1. Install the old version Desktop
2. Register device and make some P2P connections
3. Update to the new version (that is applied this change)
4. Verify that the configuration files (tareget / connection setting) is located in the backup directory

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/DESK-939>
