### PR TITLE
DESK-977 inline edit update

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteit-headless",
-  "version": "2.11.0-alpha.0",
+  "version": "2.11.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteit-headless",
-  "version": "2.11.0-alpha.0",
+  "version": "2.11.0-alpha.1",
   "private": true,
   "main": "build/index.js",
   "scripts": {

--- a/backend/src/ConnectionPool.ts
+++ b/backend/src/ConnectionPool.ts
@@ -64,7 +64,8 @@ export default class ConnectionPool {
         connection.startTime !== c.startTime ||
         connection.active !== c.active ||
         connection.connecting !== c.connecting ||
-        connection.reachable !== c.reachable
+        connection.reachable !== c.reachable ||
+        connection.sessionId !== c.sessionId
       ) {
         d('CONNECTION DIFF', {
           connection: !connection,

--- a/backend/src/cli-version.json
+++ b/backend/src/cli-version.json
@@ -1,5 +1,5 @@
 {
-  "cli": "1.6.38",
+  "cli": "1.6.39",
   "connectd": "4.11.0",
   "muxer": "0.3-alpha",
   "demuxer": "0.3-alpha",

--- a/backend/src/sharedCopy/applications.ts
+++ b/backend/src/sharedCopy/applications.ts
@@ -40,6 +40,10 @@ export class Application {
     return this.context === 'copy' ? 'Copy Command' : 'Launch URL'
   }
 
+  get defaultTemplate() {
+    return this.context === 'copy' ? this.resolvedDefaultCommandTemplate : this.resolvedDefaultLaunchTemplate
+  }
+
   get template() {
     return this.context === 'copy' ? this.commandTemplate : this.launchTemplate
   }
@@ -74,17 +78,20 @@ export class Application {
     return this.extractTokens(this.parse(this.template)) || []
   }
 
+  private get resolvedDefaultLaunchTemplate() {
+    return this.service?.attributes.launchTemplate || this.defaultLaunchTemplate
+  }
+
+  private get resolvedDefaultCommandTemplate() {
+    return this.service?.attributes.commandTemplate || this.defaultCommandTemplate || this.defaultLaunchTemplate
+  }
+
   private get launchTemplate() {
-    return this.connection?.launchTemplate || this.service?.attributes.launchTemplate || this.defaultLaunchTemplate
+    return this.connection?.launchTemplate || this.resolvedDefaultLaunchTemplate
   }
 
   private get commandTemplate() {
-    return (
-      this.connection?.commandTemplate ||
-      this.service?.attributes.commandTemplate ||
-      this.defaultCommandTemplate ||
-      this.defaultLaunchTemplate
-    )
+    return this.connection?.commandTemplate || this.resolvedDefaultCommandTemplate
   }
 
   private parse(template: string = '') {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteit-desktop-frontend",
-  "version": "2.11.0-alpha.0",
+  "version": "2.11.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteit-desktop-frontend",
-  "version": "2.11.0-alpha.0",
+  "version": "2.11.0-alpha.1",
   "private": true,
   "main": "src/server/initialize.js",
   "scripts": {

--- a/frontend/src/buttons/ConnectButton/ConnectButton.tsx
+++ b/frontend/src/buttons/ConnectButton/ConnectButton.tsx
@@ -4,7 +4,6 @@ import { DynamicButton } from '../DynamicButton'
 import { Color } from '../../styling'
 import { Fade } from '@material-ui/core'
 import { emit } from '../../services/Controller'
-import heartbeat from '../../services/Heartbeat'
 import analyticsHelper from '../../helpers/analyticsHelper'
 
 export type ConnectButtonProps = {

--- a/frontend/src/buttons/ResetButton/ResetButton.tsx
+++ b/frontend/src/buttons/ResetButton/ResetButton.tsx
@@ -2,10 +2,10 @@ import React from 'react'
 import { Tooltip, IconButton } from '@material-ui/core'
 import { Icon } from '../../components/Icon'
 
-export const ResetButton: React.FC<{ onClick?: () => void }> = ({ onClick }) => {
+export const ResetButton: React.FC<{ onClick?: () => void; onMouseDown?: () => void }> = props => {
   return (
     <Tooltip title="Reset">
-      <IconButton onClick={() => onClick && onClick()}>
+      <IconButton {...props}>
         <Icon name="undo" size="md" type="regular" fixedWidth />
       </IconButton>
     </Tooltip>

--- a/frontend/src/components/AdminPanelConnect.tsx
+++ b/frontend/src/components/AdminPanelConnect.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
-import { Notice } from './Notice'
-import { Columns } from './Columns'
 import { ServiceListItem } from './ServiceListItem'
-import { List, Typography, Divider } from '@material-ui/core'
+import { List, Divider } from '@material-ui/core'
 
 export type Props = {
   device?: IDevice

--- a/frontend/src/components/ConnectionStateIcon/ConnectionStateIcon.tsx
+++ b/frontend/src/components/ConnectionStateIcon/ConnectionStateIcon.tsx
@@ -3,7 +3,7 @@ import { Icon } from '../Icon'
 import { IconProps } from '../Icon/Icon'
 import { Tooltip } from '@material-ui/core'
 import { useHistory } from 'react-router-dom'
-import { makeStyles, IconButton, Badge, Box } from '@material-ui/core'
+import { makeStyles, IconButton, Badge } from '@material-ui/core'
 import { colors, spacing, Color } from '../../styling'
 
 export interface ConnectionStateIconProps extends Partial<IconProps> {

--- a/frontend/src/components/InlineSetting/InlineSetting.tsx
+++ b/frontend/src/components/InlineSetting/InlineSetting.tsx
@@ -30,6 +30,8 @@ type Props = {
   onShowEdit: () => void
 }
 
+let canceled = false
+
 export const InlineSetting: React.FC<Props> = ({
   label,
   icon,
@@ -46,7 +48,6 @@ export const InlineSetting: React.FC<Props> = ({
   children,
 }) => {
   const css = useStyles()
-  const [focusTimeout, setFocusTimeout] = useState<NodeJS.Timeout>()
   const [edit, setEdit] = useState<boolean>(false)
 
   function triggerEdit() {
@@ -55,10 +56,7 @@ export const InlineSetting: React.FC<Props> = ({
   }
 
   function cancelBlur() {
-    if (focusTimeout) {
-      clearTimeout(focusTimeout)
-      setFocusTimeout(undefined)
-    }
+    canceled = true
   }
 
   useEffect(() => {
@@ -66,7 +64,8 @@ export const InlineSetting: React.FC<Props> = ({
     if (edit) {
       fieldRef.current.focus()
       fieldRef.current.onblur = () => {
-        setFocusTimeout(setTimeout(() => setEdit(false), 200))
+        if (!canceled) setTimeout(() => setEdit(false), 200)
+        canceled = false
       }
     }
   }, [edit])
@@ -80,14 +79,14 @@ export const InlineSetting: React.FC<Props> = ({
           onSubmit={e => {
             e.preventDefault()
             onSubmit()
-            fieldRef.current?.blur()
+            setEdit(false)
           }}
         >
           {children}
           {resetValue != null && (
             <ResetButton
+              onMouseDown={cancelBlur}
               onClick={() => {
-                cancelBlur()
                 onResetClick()
                 fieldRef.current?.focus()
               }}
@@ -100,7 +99,7 @@ export const InlineSetting: React.FC<Props> = ({
               </IconButton>
             </Tooltip>
             <Tooltip title="Save">
-              <IconButton color="primary" type="submit">
+              <IconButton color="primary" type="submit" onMouseDown={cancelBlur}>
                 <Icon name="check" size="md" fixedWidth />
               </IconButton>
             </Tooltip>

--- a/frontend/src/components/InlineSetting/InlineSetting.tsx
+++ b/frontend/src/components/InlineSetting/InlineSetting.tsx
@@ -151,7 +151,7 @@ const useStyles = makeStyles({
     position: 'absolute',
     zIndex: 1,
     right: 'auto',
-    left: spacing.md,
+    left: spacing.lg,
     marginTop: spacing.xs,
   },
 })

--- a/frontend/src/components/InlineTemplateSetting/InlineTemplateSetting.tsx
+++ b/frontend/src/components/InlineTemplateSetting/InlineTemplateSetting.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
 import { InlineTextFieldSetting } from '../InlineTextFieldSetting'
-import { ApplicationState } from '../../store'
 import { Application } from '../../shared/applications'
 import { useApplication } from '../../hooks/useApplication'
 import { newConnection, setConnection } from '../../helpers/connectionHelper'
@@ -30,7 +28,7 @@ export const InlineTemplateSetting: React.FC<Props> = ({ service, connection, co
           </Tooltip>
         </>
       }
-      resetValue={app.template}
+      resetValue={app.defaultTemplate}
       onSave={template =>
         connection &&
         setConnection({

--- a/frontend/src/components/LocationPin.tsx
+++ b/frontend/src/components/LocationPin.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { Icon } from './Icon'
+import { Tooltip } from '@material-ui/core'
+
+export interface Props {
+  session: ISession
+}
+
+export const LocationPin: React.FC<Props> = ({ session }) => {
+  if (!session) return null
+
+  let cityState: string[] = []
+
+  if (session.geo?.city) cityState.push(session.geo.city)
+  if (session.geo?.stateName) cityState.push(session.geo.stateName)
+
+  let title: string[] = []
+
+  if (cityState.length) title.push(cityState.join(', '))
+  if (session.geo?.countryName) title.push(session.geo.countryName)
+
+  return (
+    <Tooltip title={title.join(' - ')}>
+      <span>
+        <Icon name="map-marker-alt" type="solid" size="xs" inlineLeft />
+      </span>
+    </Tooltip>
+  )
+}

--- a/frontend/src/components/PortSetting/PortSetting.tsx
+++ b/frontend/src/components/PortSetting/PortSetting.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect } from 'react'
-import { emit } from '../../services/Controller'
+import React from 'react'
 import { useSelector } from 'react-redux'
 import { InlineTextFieldSetting } from '../InlineTextFieldSetting'
 import { REGEX_PORT_SAFE } from '../../shared/constants'

--- a/frontend/src/components/Quote.tsx
+++ b/frontend/src/components/Quote.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { colors, spacing, Spacing } from '../styling'
+import { colors, spacing } from '../styling'
 import { makeStyles, Box } from '@material-ui/core'
 
 export const Quote: React.FC<{ margin?: number }> = ({ children, margin = spacing.lg }) => {

--- a/frontend/src/shared/applications.ts
+++ b/frontend/src/shared/applications.ts
@@ -40,6 +40,10 @@ export class Application {
     return this.context === 'copy' ? 'Copy Command' : 'Launch URL'
   }
 
+  get defaultTemplate() {
+    return this.context === 'copy' ? this.resolvedDefaultCommandTemplate : this.resolvedDefaultLaunchTemplate
+  }
+
   get template() {
     return this.context === 'copy' ? this.commandTemplate : this.launchTemplate
   }
@@ -74,17 +78,20 @@ export class Application {
     return this.extractTokens(this.parse(this.template)) || []
   }
 
+  private get resolvedDefaultLaunchTemplate() {
+    return this.service?.attributes.launchTemplate || this.defaultLaunchTemplate
+  }
+
+  private get resolvedDefaultCommandTemplate() {
+    return this.service?.attributes.commandTemplate || this.defaultCommandTemplate || this.defaultLaunchTemplate
+  }
+
   private get launchTemplate() {
-    return this.connection?.launchTemplate || this.service?.attributes.launchTemplate || this.defaultLaunchTemplate
+    return this.connection?.launchTemplate || this.resolvedDefaultLaunchTemplate
   }
 
   private get commandTemplate() {
-    return (
-      this.connection?.commandTemplate ||
-      this.service?.attributes.commandTemplate ||
-      this.defaultCommandTemplate ||
-      this.defaultLaunchTemplate
-    )
+    return this.connection?.commandTemplate || this.resolvedDefaultCommandTemplate
   }
 
   private parse(template: string = '') {

--- a/installer.nsh
+++ b/installer.nsh
@@ -2,7 +2,7 @@
 !include x64.nsh
 !include LogicLib.nsh
 !define REMOTEIT_BACKUP "$PROFILE\AppData\Local\remoteit-backup"
-!define PKGVERSION "2.11.0-alpha.0"
+!define PKGVERSION "2.11.0-alpha.1"
 
 !macro customInit
     Var /GLOBAL path_i

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteit",
-  "version": "2.11.0-alpha.0",
+  "version": "2.11.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteit",
-  "version": "2.11.0-alpha.0",
+  "version": "2.11.0-alpha.1",
   "private": true,
   "main": "build/index.js",
   "description": "remote.it cross platform desktop application for creating and hosting connections",


### PR DESCRIPTION
### Description

<!-- Describe, at a high level, what changes you made and why -->

1. Fix event canceling for save inline edit fields
2. sessionid connection state updates
3. Fix reset to default values for inlline edit fields
4. Remove unused imports
5. Adding missed location pin component
6. Fixing copy icon spacing
7. updating CLI to 1.6.39

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Sign in
2. Go to a service page
3. Click an inline edit field, edit the content then slow-click the save icon
4. You should see it save.

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/DESK-977>
