### PR TITLE
DESK-983 DESK-982 DESK-544  Separate out enabled and connected states from active state so that c…

### DIFF
--- a/backend/src/CLI.ts
+++ b/backend/src/CLI.ts
@@ -33,6 +33,7 @@ type IExec = {
 
 type IConnectionStatus = {
   id?: string
+  enabled?: boolean
   state?: 'offline' | 'connecting' | 'connected'
   isFailover?: boolean
   isP2P?: boolean
@@ -112,6 +113,7 @@ export default class CLI {
       id: c.uid,
       port: c.port,
       host: c.hostname,
+      enabled: !c.disabled,
       createdTime: Math.round(c.createdtimestamp / 1000000),
       startTime: Math.round((c.startedtimestamp || c.createdtimestamp) / 1000000),
       endTime: Math.round(c.stoppedtimestamp / 1000000),
@@ -133,7 +135,7 @@ export default class CLI {
     this.data.connections = this.data.connections.map(c => {
       const status = connections?.find(s => s.id === c.id)
       if (status) {
-        c.active = status.state === 'connected'
+        c.connected = status.state === 'connected'
         c.connecting = status.state === 'connecting'
         c.isP2P = status.state === 'connected' ? status.isP2P : undefined
         c.reachable = status.reachable

--- a/backend/src/Connection.ts
+++ b/backend/src/Connection.ts
@@ -30,7 +30,6 @@ export default class Connection extends EventEmitter {
   start() {
     this.params.enabled = true
     this.params.connecting = true
-    this.params.disconnecting = false
     this.params.startTime = Date.now()
     this.params.error = undefined
     // if (cli.data.connections.find(c => c.id === this.params.id)) cli.setConnection(this.params, this.error) else
@@ -41,7 +40,6 @@ export default class Connection extends EventEmitter {
   stop() {
     this.params.enabled = false
     this.params.connecting = false
-    this.params.disconnecting = true
     this.params.endTime = Date.now()
     cli.setConnection(this.params, this.error)
     EventBus.emit(Connection.EVENTS.disconnected, { connection: this.params } as ConnectionMessage)
@@ -50,7 +48,6 @@ export default class Connection extends EventEmitter {
   async clear() {
     this.params.enabled = false
     this.params.connecting = false
-    this.params.disconnecting = false
     this.params.startTime = undefined
     this.params.error = undefined
     await cli.removeConnection(this.params, this.error)

--- a/backend/src/Connection.ts
+++ b/backend/src/Connection.ts
@@ -28,7 +28,9 @@ export default class Connection extends EventEmitter {
   }
 
   start() {
+    this.params.enabled = true
     this.params.connecting = true
+    this.params.disconnecting = false
     this.params.startTime = Date.now()
     this.params.error = undefined
     // if (cli.data.connections.find(c => c.id === this.params.id)) cli.setConnection(this.params, this.error) else
@@ -37,15 +39,18 @@ export default class Connection extends EventEmitter {
   }
 
   stop() {
-    d('Stopping service:', this.params.id)
-    this.params.active = false
+    this.params.enabled = false
+    this.params.connecting = false
+    this.params.disconnecting = true
     this.params.endTime = Date.now()
     cli.setConnection(this.params, this.error)
     EventBus.emit(Connection.EVENTS.disconnected, { connection: this.params } as ConnectionMessage)
   }
 
   async clear() {
+    this.params.enabled = false
     this.params.connecting = false
+    this.params.disconnecting = false
     this.params.startTime = undefined
     this.params.error = undefined
     await cli.removeConnection(this.params, this.error)
@@ -53,7 +58,7 @@ export default class Connection extends EventEmitter {
 
   error = (e: Error) => {
     this.params.error = { message: e.message }
-    this.params.active = false
+    this.params.connected = false
     this.params.endTime = Date.now()
     EventBus.emit(Connection.EVENTS.error, { ...this.params.error, connection: this.params } as ConnectionErrorMessage)
   }

--- a/backend/src/ConnectionPool.ts
+++ b/backend/src/ConnectionPool.ts
@@ -215,7 +215,7 @@ export default class ConnectionPool {
     const legacyFile = new JSONFile<IConnection[]>(path.join(environment.userPath, 'connections.json'))
     if (legacyFile.exists) {
       Logger.info('MIGRATING LEGACY CONNECTIONS FILE')
-      const data = legacyFile.read() || []
+      const data = legacyFile.read()
       Logger.info('COPYING CONNECTIONS DATA', { data })
       this.file.write(data)
       legacyFile.remove()

--- a/backend/src/ConnectionPool.ts
+++ b/backend/src/ConnectionPool.ts
@@ -31,7 +31,8 @@ export default class ConnectionPool {
     this.file = new JSONFile<IConnection[]>(path.join(environment.userPath, `connections/${user.id}.json`))
     this.migrateLegacyFile()
 
-    const connections: IConnection[] = this.file.read() || []
+    let connections: IConnection[] = this.file.read() || []
+    connections = this.migrateConnectionData(connections)
 
     Logger.info('INITIALIZING CONNECTIONS', { file: this.file.location, length: connections.length })
 
@@ -61,25 +62,20 @@ export default class ConnectionPool {
       d('SYNC CLI CONNECTION', { connection, c })
       if (
         !connection ||
+        connection.enabled !== c.enabled ||
         connection.startTime !== c.startTime ||
-        connection.active !== c.active ||
+        connection.connected !== c.connected ||
         connection.connecting !== c.connecting ||
         connection.reachable !== c.reachable ||
         connection.sessionId !== c.sessionId
       ) {
-        d('CONNECTION DIFF', {
-          connection: !connection,
-          startTime: connection?.startTime !== c.startTime,
-          active: connection?.active !== c.active,
-          connecting: connection?.connecting !== c.connecting,
-        })
         this.set({ ...connection, ...c })
       }
     })
     // start any connections: desktop -> cli
     this.pool.forEach(connection => {
       const cliConnection = cli.data.connections.find(c => c.id === connection.params.id)
-      if (!cliConnection && connection.params.active) {
+      if (!cliConnection && connection.params.connected) {
         Logger.info('SYNC START CONNECTION', { connection: connection.params })
         connection.start()
       }
@@ -152,7 +148,7 @@ export default class ConnectionPool {
 
   clearRecent = () => {
     this.pool = this.pool.filter(async connection => {
-      if (connection.params.active) return true
+      if (connection.params.connected) return true
       await connection.clear()
       return false
     })
@@ -177,8 +173,8 @@ export default class ConnectionPool {
       .map(c => c.params)
       .sort((a, b) => {
         return (
-          this.sort(a.active, b.active) ||
-          (a.active ? this.sort(a.startTime, b.startTime) : this.sort(a.endTime, b.endTime))
+          this.sort(a.connected, b.connected) ||
+          (a.connected ? this.sort(a.startTime, b.startTime) : this.sort(a.endTime, b.endTime))
         )
       })
   }
@@ -219,10 +215,19 @@ export default class ConnectionPool {
     const legacyFile = new JSONFile<IConnection[]>(path.join(environment.userPath, 'connections.json'))
     if (legacyFile.exists) {
       Logger.info('MIGRATING LEGACY CONNECTIONS FILE')
-      const data = legacyFile.read()
+      const data = legacyFile.read() || []
       Logger.info('COPYING CONNECTIONS DATA', { data })
       this.file.write(data)
       legacyFile.remove()
     }
+  }
+
+  private migrateConnectionData(connections: IConnection[]) {
+    // migrate active to enabled and connected
+    return connections.map(c => {
+      const enabled = c.active
+      delete c.active
+      return { ...c, enabled, connected: enabled }
+    })
   }
 }

--- a/backend/src/cli-version.json
+++ b/backend/src/cli-version.json
@@ -1,5 +1,5 @@
 {
-  "cli": "1.6.47",
+  "cli": "1.6.48",
   "connectd": "4.12.0",
   "muxer": "0.3-alpha",
   "demuxer": "0.3-alpha",

--- a/backend/src/cliStrings.ts
+++ b/backend/src/cliStrings.ts
@@ -69,7 +69,7 @@ export default {
   setConnect(c: IConnection) {
     return `-j connection modify --id ${c.id} --name "${c.name}" --port ${c.port} --hostname ${c.host} --restrict ${
       c.restriction
-    } --retry ${!!c.autoStart} --failover ${!!c.failover} --p2p ${!c.proxyOnly} --enable ${!!c.active} --servicetype ${
+    } --retry ${!!c.autoStart} --failover ${!!c.failover} --p2p ${!c.proxyOnly} --enable ${!!c.enabled} --servicetype ${
       c.typeID
     } --authhash ${user.authHash} --manufacture-id ${environment.appCode}`
   },

--- a/common/types.d.ts
+++ b/common/types.d.ts
@@ -123,7 +123,8 @@ declare global {
     deviceID: string
     online: boolean // online if service is online
     port?: number
-    active?: boolean // active if connected
+    connected?: boolean
+    enabled?: boolean // if the connection is active
     host?: ipAddress // Bind address
     typeID?: number // service type ID
     restriction?: ipAddress // Restriction IP address

--- a/frontend/src/buttons/ClearButton/ClearButton.tsx
+++ b/frontend/src/buttons/ClearButton/ClearButton.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 export const ClearButton: React.FC<Props> = ({ disabled = false, connection, all }) => {
   const location = useLocation()
-  if (!all && (!connection || connection.active || !connection.startTime)) return null
+  if (!all && (!connection || connection.connected || !connection.startTime)) return null
   if (!location.pathname.includes('connections')) return null
 
   const forget = () => {

--- a/frontend/src/buttons/ComboButton/ComboButton.tsx
+++ b/frontend/src/buttons/ComboButton/ComboButton.tsx
@@ -18,6 +18,10 @@ export const ComboButton: React.FC<Props> = ({ connection, service, className })
       <ConnectButton connection={connection} service={service} size="small" />
       <DisconnectButton connection={connection} service={service} size="small" />
       <OfflineButton connection={connection} service={service} />
+      {connection?.connecting && 'connecting '}
+      {connection?.enabled && 'enabled '}
+      {connection?.connected && 'connected '}
+      {connection?.disconnecting && 'disconnecting'}
     </div>
   )
 }

--- a/frontend/src/buttons/ComboButton/ComboButton.tsx
+++ b/frontend/src/buttons/ComboButton/ComboButton.tsx
@@ -18,10 +18,6 @@ export const ComboButton: React.FC<Props> = ({ connection, service, className })
       <ConnectButton connection={connection} service={service} size="small" />
       <DisconnectButton connection={connection} service={service} size="small" />
       <OfflineButton connection={connection} service={service} />
-      {connection?.connecting && 'connecting '}
-      {connection?.enabled && 'enabled '}
-      {connection?.connected && 'connected '}
-      {connection?.disconnecting && 'disconnecting'}
     </div>
   )
 }

--- a/frontend/src/buttons/ConnectButton/ConnectButton.tsx
+++ b/frontend/src/buttons/ConnectButton/ConnectButton.tsx
@@ -22,7 +22,7 @@ export const ConnectButton: React.FC<ConnectButtonProps> = ({
   autoConnect,
 }) => {
   const [autoStart, setAutoStart] = useState<boolean>(!!autoConnect)
-  const hidden = connection?.active || !service || service.state !== 'active'
+  const hidden = connection?.connected || !service || service.state !== 'active'
   const connecting = !!connection?.connecting
 
   const clickHandler = () => {

--- a/frontend/src/buttons/ConnectButton/ConnectButton.tsx
+++ b/frontend/src/buttons/ConnectButton/ConnectButton.tsx
@@ -22,8 +22,9 @@ export const ConnectButton: React.FC<ConnectButtonProps> = ({
   autoConnect,
 }) => {
   const [autoStart, setAutoStart] = useState<boolean>(!!autoConnect)
-  const hidden = connection?.connected || !service || service.state !== 'active'
+  const hidden = connection?.connected || service?.state !== 'active'
   const connecting = !!connection?.connecting
+  const listening = connection?.enabled && !connection.connected
 
   const clickHandler = () => {
     if (connecting) {
@@ -58,6 +59,10 @@ export const ConnectButton: React.FC<ConnectButtonProps> = ({
     variant = 'text'
   }
 
+  if (listening) {
+    title = 'Listening'
+  }
+
   return (
     <Fade in={!hidden} timeout={600}>
       <div>
@@ -66,7 +71,7 @@ export const ConnectButton: React.FC<ConnectButtonProps> = ({
           icon="exchange"
           variant={variant}
           loading={connecting}
-          color={connecting ? undefined : color}
+          color={connecting ? 'gray' : color}
           size={size}
           onClick={clickHandler}
           disabled={disabled}

--- a/frontend/src/buttons/CopyButton.tsx
+++ b/frontend/src/buttons/CopyButton.tsx
@@ -31,7 +31,7 @@ export const CopyButton: React.FC<CopyButtonProps> = ({
   const clipboard = useClipboard({ copiedTimeout: 1000 })
   const app = useApplication(context, service, connection)
 
-  if (!connection || (!show && (!connection.active || !app))) return null
+  if (!connection || (!show && (!connection.connected || !app))) return null
 
   const check = event => {
     event.preventDefault()

--- a/frontend/src/buttons/DisconnectButton/DisconnectButton.tsx
+++ b/frontend/src/buttons/DisconnectButton/DisconnectButton.tsx
@@ -14,15 +14,16 @@ type Props = {
 
 export const DisconnectButton: React.FC<Props> = ({ service, size = 'medium', color = 'primary', connection }) => {
   const hidden = !connection || !connection.connected
-  const connecting = !!connection?.connecting
+  const disconnecting = !connection?.enabled && !!connection?.connected
   return (
     <Fade in={!hidden} timeout={600}>
       <div>
         <DynamicButton
-          title={connecting ? 'Connecting' : 'Disconnect'}
+          title={disconnecting ? 'Stopping' : 'Disconnect'}
           icon="ban"
-          loading={connecting}
-          color={connecting ? 'grayDark' : color}
+          disabled={disconnecting}
+          loading={disconnecting}
+          color={disconnecting ? 'grayDark' : color}
           size={size}
           onClick={() => {
             analyticsHelper.trackConnect('connectionClosed', service)

--- a/frontend/src/buttons/DisconnectButton/DisconnectButton.tsx
+++ b/frontend/src/buttons/DisconnectButton/DisconnectButton.tsx
@@ -13,7 +13,7 @@ type Props = {
 }
 
 export const DisconnectButton: React.FC<Props> = ({ service, size = 'medium', color = 'primary', connection }) => {
-  const hidden = !connection || !connection.active
+  const hidden = !connection || !connection.connected
   const connecting = !!connection?.connecting
   return (
     <Fade in={!hidden} timeout={600}>

--- a/frontend/src/buttons/EditButton/EditButton.tsx
+++ b/frontend/src/buttons/EditButton/EditButton.tsx
@@ -19,7 +19,7 @@ export const EditButton: React.FC<Props> = ({ onClick, device, service, connecti
   if (service) title += ' Service'
   else if (device) title += ' Device'
 
-  if ((service && device?.shared) || connection?.active) return null
+  if ((service && device?.shared) || connection?.connected) return null
   if (instance) onClick = () => history.push(location.pathname + '/edit')
 
   return (

--- a/frontend/src/buttons/ForgetButton/ForgetButton.tsx
+++ b/frontend/src/buttons/ForgetButton/ForgetButton.tsx
@@ -14,7 +14,7 @@ export const ForgetButton: React.FC<Props> = ({ disabled = false, connection }) 
   const history = useHistory()
   const location = useLocation()
 
-  if (!connection || connection.active) return null
+  if (!connection || connection.connected) return null
 
   const forget = () => {
     emit('service/forget', connection)

--- a/frontend/src/buttons/LaunchButton/LaunchButton.tsx
+++ b/frontend/src/buttons/LaunchButton/LaunchButton.tsx
@@ -53,7 +53,7 @@ export const LaunchButton: React.FC<Props> = ({ connection, service, menuItem, s
     }
   }, [requireInstall, launch, app])
 
-  if (!connection || !connection.active || !app) return null
+  if (!connection || !connection.connected || !app) return null
 
   const launchBrowser = () => {
     let launchApp: ILaunchApp | undefined

--- a/frontend/src/buttons/OfflineButton/OfflineButton.tsx
+++ b/frontend/src/buttons/OfflineButton/OfflineButton.tsx
@@ -8,7 +8,7 @@ type Props = {
 }
 
 export const OfflineButton: React.FC<Props> = ({ service, connection }) => {
-  const hidden = service?.state === 'active' || connection?.active
+  const hidden = service?.state === 'active' || connection?.connected
   return (
     <Fade in={!hidden} timeout={600}>
       <div>

--- a/frontend/src/components/AutoStartSetting/AutoStartSetting.tsx
+++ b/frontend/src/components/AutoStartSetting/AutoStartSetting.tsx
@@ -8,7 +8,7 @@ export const AutoStartSetting: React.FC<{ service: IService; connection?: IConne
 }) => {
   if (!service) return null
   if (!connection) connection = newConnection(service)
-  const disabled = connection?.active || connection?.connecting || service.state !== 'active'
+  const disabled = connection?.connected || connection?.connecting || service.state !== 'active'
 
   return (
     <ListItemSetting

--- a/frontend/src/components/ConnectionLogSetting.tsx
+++ b/frontend/src/components/ConnectionLogSetting.tsx
@@ -9,7 +9,7 @@ export const ConnectionLogSetting: React.FC<{ service: IService; connection?: IC
 }) => {
   if (!service) return null
   if (!connection) connection = newConnection(service)
-  const disabled = connection?.active || connection?.connecting || service.state !== 'active'
+  const disabled = connection?.connected || connection?.connecting || service.state !== 'active'
 
   return (
     <ListItemSetting

--- a/frontend/src/components/ConnectionStateIcon/ConnectionStateIcon.tsx
+++ b/frontend/src/components/ConnectionStateIcon/ConnectionStateIcon.tsx
@@ -33,7 +33,7 @@ export function ConnectionStateIcon({
   let state = instance?.state || ''
 
   if (connection) {
-    if (connection.active) state = 'connected'
+    if (connection.connected) state = 'connected'
     if (connection.connecting) state = 'connecting'
   }
 

--- a/frontend/src/components/ConnectionsList/ConnectionsList.tsx
+++ b/frontend/src/components/ConnectionsList/ConnectionsList.tsx
@@ -13,8 +13,8 @@ export interface Props {
 
 export const ConnectionsList: React.FC<Props> = ({ connections, services }) => {
   const css = useStyles()
-  const connected = connections.filter(c => c.active)
-  const recent = connections.filter(c => !c.active)
+  const connected = connections.filter(c => c.connected)
+  const recent = connections.filter(c => !c.connected)
 
   return (
     <List>

--- a/frontend/src/components/DeviceListItem/DeviceListItem.tsx
+++ b/frontend/src/components/DeviceListItem/DeviceListItem.tsx
@@ -50,7 +50,7 @@ const ServiceIndicators: React.FC<Props> = ({ device, connections = [], setConte
 }
 
 export const DeviceListItem: React.FC<Props> = ({ device, connections, thisDevice, setContextMenu, restore }) => {
-  const activeConnection = connections && connections.find(c => c.active)
+  const connected = connections && connections.find(c => c.connected)
   const largeScreen = useMediaQuery('(min-width:600px)')
 
   if (!device) return null
@@ -59,10 +59,10 @@ export const DeviceListItem: React.FC<Props> = ({ device, connections, thisDevic
     <ListItemLocation pathname={`/devices/${device.id}`}>
       <DeviceLabel device={device} />
       <ListItemIcon>
-        <ConnectionStateIcon device={device} connection={activeConnection} size="lg" thisDevice={thisDevice} />
+        <ConnectionStateIcon device={device} connection={connected} size="lg" thisDevice={thisDevice} />
       </ListItemIcon>
       <ListItemText
-        primary={<ServiceName device={device} connection={activeConnection} />}
+        primary={<ServiceName device={device} connection={connected} />}
         secondary={thisDevice && 'This system'}
       />
       {restore ? (

--- a/frontend/src/components/HostSetting/HostSetting.tsx
+++ b/frontend/src/components/HostSetting/HostSetting.tsx
@@ -9,7 +9,7 @@ export const HostSetting: React.FC<{ service: IService; connection?: IConnection
   if (!connection) connection = newConnection(service)
 
   const currentHost = (connection && connection.host) || IP_PRIVATE
-  const disabled = connection.active || connection.connecting
+  const disabled = connection.connected || connection.connecting
 
   return (
     <InlineTextFieldSetting

--- a/frontend/src/components/LanShareSelect/LanShareSelect.tsx
+++ b/frontend/src/components/LanShareSelect/LanShareSelect.tsx
@@ -13,7 +13,7 @@ type Props = {
 export const LanShareSelect: React.FC<Props> = ({ connection, service }) => {
   const location = useLocation()
   const shared = lanShared(connection)
-  const disabled = connection?.active || connection?.connecting || service.state !== 'active'
+  const disabled = connection?.connected || connection?.connecting || service.state !== 'active'
   const color = shared ? 'primary' : undefined
   return (
     <ListItemLocation disabled={disabled} pathname={location.pathname + '/lan'} dense>

--- a/frontend/src/components/PortSetting/PortSetting.tsx
+++ b/frontend/src/components/PortSetting/PortSetting.tsx
@@ -13,7 +13,7 @@ export const PortSetting: React.FC<{ service: IService; connection?: IConnection
   if (!service) return null
   if (!connection) connection = newConnection(service)
 
-  const disabled = connection.active || connection.connecting
+  const disabled = connection.connected || connection.connecting
   const save = (port?: number) =>
     connection &&
     setConnection({

--- a/frontend/src/components/ProxySetting/ProxySetting.tsx
+++ b/frontend/src/components/ProxySetting/ProxySetting.tsx
@@ -8,7 +8,7 @@ export const ProxySetting: React.FC<{ service: IService; connection?: IConnectio
   if (!service) return null
   if (!connection) connection = newConnection(service)
 
-  const disabled = connection.active || connection.connecting || service.state !== 'active'
+  const disabled = connection.connected || connection.connecting || service.state !== 'active'
   const connectionRoute: IRouteType = connection.proxyOnly ? 'proxy' : connection.failover ? 'failover' : 'p2p'
   const route = ROUTES.find(r => r.key === connectionRoute)
 

--- a/frontend/src/components/ServiceConnected/ServiceConnected.tsx
+++ b/frontend/src/components/ServiceConnected/ServiceConnected.tsx
@@ -12,7 +12,7 @@ type Props = {
 }
 
 export const ServiceConnected: React.FC<Props> = ({ connection, service }) => {
-  const visible = connection?.active
+  const visible = connection?.connected
 
   return (
     <Collapse in={visible} timeout={800}>

--- a/frontend/src/components/ServiceMiniState/ServiceMiniState.tsx
+++ b/frontend/src/components/ServiceMiniState/ServiceMiniState.tsx
@@ -29,8 +29,8 @@ export const ServiceMiniState: React.FC<Props> = ({ connection, service, setCont
 
   if (connection) {
     failover = connection.isP2P === false
-    if (connection.connecting && !connection.active) state = 'connecting'
-    if (connection.active) state = 'connected'
+    if (connection.connecting && !connection.connected) state = 'connecting'
+    if (connection.connected) state = 'connected'
     if (connection.error?.message) state = 'error'
   }
 

--- a/frontend/src/helpers/connectionHelper.ts
+++ b/frontend/src/helpers/connectionHelper.ts
@@ -63,6 +63,7 @@ export function setConnection(connection: IConnection) {
     console.warn('Connection missing data. Set failed', connection, error.stack)
     return false
   }
+  console.log('SET CONNECTION', connection.name, connection.enabled)
   emit('connection', connection)
 }
 

--- a/frontend/src/models/backend.ts
+++ b/frontend/src/models/backend.ts
@@ -164,7 +164,6 @@ export default createModel<RootModel>()({
       const state = globalState.backend
       state.connections.some((c, index) => {
         if (c.id === connection.id) {
-          console.log('UPDATE CONNECTION', connection.name, connection.enabled)
           state.connections[index] = connection
           dispatch.backend.set({ connections: state.connections })
           if (connection) return true
@@ -174,7 +173,6 @@ export default createModel<RootModel>()({
     },
     async updateConnections(connections: IConnection[], globalState) {
       connections.forEach(connection => {
-        console.log('UPDATE CONNECTIONS', connection.name, connection.enabled)
         // data missing from cli if our connections file is lost
         if (!connection.owner) {
           const [service] = selectService(globalState, connection.id)

--- a/frontend/src/models/backend.ts
+++ b/frontend/src/models/backend.ts
@@ -164,6 +164,7 @@ export default createModel<RootModel>()({
       const state = globalState.backend
       state.connections.some((c, index) => {
         if (c.id === connection.id) {
+          console.log('UPDATE CONNECTION', connection.name, connection.enabled)
           state.connections[index] = connection
           dispatch.backend.set({ connections: state.connections })
           if (connection) return true
@@ -173,6 +174,7 @@ export default createModel<RootModel>()({
     },
     async updateConnections(connections: IConnection[], globalState) {
       connections.forEach(connection => {
+        console.log('UPDATE CONNECTIONS', connection.name, connection.enabled)
         // data missing from cli if our connections file is lost
         if (!connection.owner) {
           const [service] = selectService(globalState, connection.id)

--- a/frontend/src/models/devices.ts
+++ b/frontend/src/models/devices.ts
@@ -303,7 +303,7 @@ export default createModel<RootModel>()({
 const isIService = (instance: any): instance is IService => !!instance?.license
 
 export function isOffline(instance?: IDevice | IService, connection?: IConnection) {
-  const inactive = instance?.state !== 'active' && !connection?.active
+  const inactive = instance?.state !== 'active' && !connection?.connected
   const unlicensed = isIService(instance) && instance.license === 'UNLICENSED'
   return inactive || unlicensed
 }

--- a/frontend/src/pages/ServiceDetailPage/ServiceDetailPage.tsx
+++ b/frontend/src/pages/ServiceDetailPage/ServiceDetailPage.tsx
@@ -26,7 +26,7 @@ export const ServiceDetailPage = () => {
 
   if (!service || !device) return null
 
-  if (connection && connection.active) {
+  if (connection && connection.connected) {
     data = data.concat([
       { label: 'Host', value: connection.host },
       { label: 'Port', value: connection.port },

--- a/frontend/src/pages/ServicesPage/ServicesPage.tsx
+++ b/frontend/src/pages/ServicesPage/ServicesPage.tsx
@@ -40,7 +40,7 @@ export const ServicesPage: React.FC = () => {
   const thisDevice = deviceID === thisDeviceId
   const history = useHistory()
   const location = useLocation()
-  const activeConnection = connections.find(c => c.deviceID === deviceID && c.active)
+  const connected = connections.find(c => c.deviceID === deviceID && c.connected)
   const serviceConnections = connections.reduce((result: ConnectionLookup, c: IConnection) => {
     result[c.id] = c
     return result
@@ -67,8 +67,8 @@ export const ServicesPage: React.FC = () => {
         <>
           <Breadcrumbs />
           <Typography variant="h1">
-            <ConnectionStateIcon device={device} connection={activeConnection} thisDevice={thisDevice} size="lg" />
-            <ServiceName device={device} connection={activeConnection} inline />
+            <ConnectionStateIcon device={device} connection={connected} thisDevice={thisDevice} size="lg" />
+            <ServiceName device={device} connection={connected} inline />
             <EditButton device={device} />
             <AddUserButton device={device} />
             <RefreshButton device={device} />

--- a/frontend/src/services/cloudController.ts
+++ b/frontend/src/services/cloudController.ts
@@ -216,7 +216,7 @@ class CloudController {
         event.target.forEach(target => {
           // Local connection state
           if (target.connection) {
-            target.connection.active = event.state === 'connected'
+            target.connection.connected = event.state === 'connected'
             target.connection.connecting = false
             setConnection(target.connection)
           }
@@ -245,7 +245,7 @@ class CloudController {
             }
           }
 
-          console.log('CONNECTION STATE', target.connection?.name, target.connection?.active)
+          console.log('CONNECTION STATE', target.connection?.name, target.connection?.connected)
         })
         break
 

--- a/src/TrayMenu.ts
+++ b/src/TrayMenu.ts
@@ -84,10 +84,10 @@ export default class TrayMenu {
 
   private connectionsMenu() {
     let menu = []
-    const active = this.pool.filter(c => c.active)
-    const recent = this.pool.filter(c => !c.active)
-    if (active.length) menu.push({ label: 'Active connections', enabled: false }, ...this.connectionsList(active))
-    if (active.length && recent.length) menu.push({ type: 'separator' })
+    const connected = this.pool.filter(c => c.connected)
+    const recent = this.pool.filter(c => !c.connected)
+    if (connected.length) menu.push({ label: 'Active connections', enabled: false }, ...this.connectionsList(connected))
+    if (connected.length && recent.length) menu.push({ type: 'separator' })
     if (recent.length)
       menu.push(
         { label: 'Recent connections', enabled: false },
@@ -113,9 +113,9 @@ export default class TrayMenu {
       if (connection.startTime) {
         result.push({
           label: connection.name,
-          icon: connection.active ? iconConnected : connection.online ? iconOnline : iconOffline,
+          icon: connection.connected ? iconConnected : connection.online ? iconOnline : iconOffline,
           submenu: [
-            connection.active
+            connection.connected
               ? { label: 'Disconnect', click: () => this.disconnect(connection) }
               : connection.online
               ? { label: 'Connect', click: () => this.connect(connection) }
@@ -124,7 +124,7 @@ export default class TrayMenu {
             { label: hostName(connection), enabled: false },
             { label: 'Copy to clipboard', click: () => this.copy(connection) },
             connection.online
-              ? { label: 'Launch', enabled: connection.active, click: () => this.launch(connection) }
+              ? { label: 'Launch', enabled: connection.connected, click: () => this.launch(connection) }
               : { label: 'Remove', click: () => EventBus.emit(EVENTS.clear, connection) },
           ],
         })


### PR DESCRIPTION

### Description

<!-- Describe, at a high level, what changes you made and why -->
 Separate out enabled and connected states from active state so that cloud close events don't disconnect

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Sign in
2. Go to a service and set to proxy only
3. Click connect and wait 15 minutes for disconnect event to come in
4. You should stay connected

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/DESK-983>
<https://remoteit.atlassian.net/browse/DESK-982>
<https://remoteit.atlassian.net/browse/DESK-544>
