### PR TITLE
DESK-997 Changing restore state from model to route

### DIFF
--- a/frontend/src/buttons/RestoreButton.tsx
+++ b/frontend/src/buttons/RestoreButton.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { useHistory } from 'react-router-dom'
 import { emit } from '../services/Controller'
 import { Button } from '@material-ui/core'
 import { Dispatch } from '../store'
@@ -7,6 +8,7 @@ import { Confirm } from '../components/Confirm'
 
 export const RestoreButton: React.FC<{ device: IDevice; onClick?: () => void }> = ({ device, onClick }) => {
   const [open, setOpen] = useState<boolean>(false)
+  const history = useHistory()
   const { ui } = useDispatch<Dispatch>()
 
   return (
@@ -17,8 +19,9 @@ export const RestoreButton: React.FC<{ device: IDevice; onClick?: () => void }> 
       <Confirm
         open={open}
         onConfirm={() => {
-          ui.set({ restoring: true, restore: false })
+          ui.set({ restoring: true })
           emit('restore', device.id)
+          history.push('/devices')
         }}
         onDeny={() => setOpen(false)}
         title="Restore device from Cloud"

--- a/frontend/src/components/DeviceList/DeviceList.tsx
+++ b/frontend/src/components/DeviceList/DeviceList.tsx
@@ -11,17 +11,17 @@ import { LoadMore } from '../LoadMore'
 import { Notice } from '../Notice'
 
 export interface DeviceListProps {
-  devices?: IDevice[]
   connections: { [deviceID: string]: IConnection[] }
+  devices?: IDevice[]
+  restore?: boolean
 }
 
-export const DeviceList: React.FC<DeviceListProps> = ({ devices = [], connections = {} }) => {
+export const DeviceList: React.FC<DeviceListProps> = ({ devices = [], connections = {}, restore }) => {
   const [contextMenu, setContextMenu] = React.useState<IContextMenu>({})
-  const { myDevice, loggedInUser, registeredId, restore } = useSelector((state: ApplicationState) => ({
+  const { myDevice, loggedInUser, registeredId } = useSelector((state: ApplicationState) => ({
     registeredId: state.backend.device.uid,
     loggedInUser: getActiveAccountId(state) === state.auth.user?.id,
     myDevice: getOwnDevices(state).find(device => device.id === state.backend.device.uid),
-    restore: state.ui.restore,
   }))
 
   return (
@@ -50,7 +50,7 @@ export const DeviceList: React.FC<DeviceListProps> = ({ devices = [], connection
           ))
         ) : (
           <>
-            <DeviceSetupItem />
+            <DeviceSetupItem restore={restore} />
             <Divider variant="inset" />
           </>
         )}

--- a/frontend/src/components/DeviceSetupItem/DeviceSetupItem.tsx
+++ b/frontend/src/components/DeviceSetupItem/DeviceSetupItem.tsx
@@ -69,14 +69,7 @@ export const DeviceSetupItem: React.FC<{ restore?: boolean }> = ({ restore }) =>
               <Link onClick={() => history.push('/devices')}>cancel</Link>
             </Typography>
           ) : (
-            <Button
-              variant="outlined"
-              size="small"
-              onClick={() => {
-                console.log('---------click------------')
-                history.push('/devices/restore')
-              }}
-            >
+            <Button variant="outlined" size="small" onClick={() => history.push('/devices/restore')}>
               Restore Device
             </Button>
           )}

--- a/frontend/src/components/DeviceSetupItem/DeviceSetupItem.tsx
+++ b/frontend/src/components/DeviceSetupItem/DeviceSetupItem.tsx
@@ -18,19 +18,17 @@ import { Notice } from '../../components/Notice'
 import { osName } from '../../shared/nameHelper'
 import { Icon } from '../Icon'
 
-export const DeviceSetupItem: React.FC = () => {
-  const { ui } = useDispatch<Dispatch>()
+export const DeviceSetupItem: React.FC<{ restore?: boolean }> = ({ restore }) => {
   const history = useHistory()
-  const { thisDevice, targetDevice, os, canRestore, restore, restoring } = useSelector((state: ApplicationState) => ({
+  const { thisDevice, targetDevice, os, canRestore, restoring } = useSelector((state: ApplicationState) => ({
     thisDevice: getOwnDevices(state).find(d => d.id === state.backend.device.uid),
     targetDevice: state.backend.device,
     os: state.backend.environment.os,
+    restoring: state.ui.restoring,
     canRestore:
       !state.backend.device.uid &&
       (state.devices.total > state.devices.size ||
         !!getOwnDevices(state).find((d: IDevice) => d.state !== 'active' && !d.shared)),
-    restore: state.ui.restore,
-    restoring: state.ui.restoring,
   }))
 
   if (restoring)
@@ -68,15 +66,15 @@ export const DeviceSetupItem: React.FC = () => {
           {restore ? (
             <Typography variant="body2" color="textSecondary">
               Select a device or
-              <Link onClick={() => ui.set({ restore: false })}>cancel</Link>
+              <Link onClick={() => history.push('/devices')}>cancel</Link>
             </Typography>
           ) : (
             <Button
               variant="outlined"
               size="small"
               onClick={() => {
-                ui.set({ restore: true })
-                history.push('/devices')
+                console.log('---------click------------')
+                history.push('/devices/restore')
               }}
             >
               Restore Device

--- a/frontend/src/models/ui.ts
+++ b/frontend/src/models/ui.ts
@@ -12,7 +12,6 @@ type UIState = {
   routingMessage?: string
   filterMenu: boolean
   redirect?: string
-  restore: boolean
   restoring: boolean
   scanEnabled: boolean
   scanLoading: { [interfaceName: string]: boolean }
@@ -47,7 +46,6 @@ const state: UIState = {
   routingMessage: undefined,
   filterMenu: false,
   redirect: undefined,
-  restore: false,
   restoring: false,
   scanEnabled: true,
   scanLoading: {},

--- a/frontend/src/pages/DevicesPage/DevicesPage.tsx
+++ b/frontend/src/pages/DevicesPage/DevicesPage.tsx
@@ -16,7 +16,7 @@ import { Container } from '../../components/Container'
 import styles from '../../styling'
 import analyticsHelper from '../../helpers/analyticsHelper'
 
-export const DevicesPage: React.FC<{ singlePanel?: boolean }> = ({ singlePanel }) => {
+export const DevicesPage: React.FC<{ singlePanel?: boolean; restore?: boolean }> = ({ singlePanel, restore }) => {
   const { devices, connections, fetching } = useSelector((state: ApplicationState) => ({
     fetching: state.devices.fetching,
     devices: getDevices(state).filter((d: IDevice) => !d.hidden),
@@ -58,7 +58,7 @@ export const DevicesPage: React.FC<{ singlePanel?: boolean }> = ({ singlePanel }
       ) : !devices.length ? (
         <DeviceListEmpty />
       ) : (
-        <DeviceList devices={devices} connections={connections} />
+        <DeviceList devices={devices} connections={connections} restore={restore} />
       )}
     </Container>
   )

--- a/frontend/src/routers/Router.tsx
+++ b/frontend/src/routers/Router.tsx
@@ -102,6 +102,12 @@ export const Router: React.FC<{ singlePanel?: boolean }> = ({ singlePanel }) => 
         </Panel>
       </Route>
 
+      <Route path="/devices/restore">
+        <Panel>
+          <DevicesPage singlePanel={singlePanel} restore />
+        </Panel>
+      </Route>
+
       <Route path="/devices/:deviceID">
         <DeviceRouter singlePanel={singlePanel} />
       </Route>


### PR DESCRIPTION
### Description

<!-- Describe, at a high level, what changes you made and why -->

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Sign in on a system without a device
2. Click restore button
3. Click the "Register services" button instead of restoring
4. You should see the setup screen and then after finished should see the device list as normal, not in the restore state.

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/DESK-997 >
