### PR TITLE
[DESK-1013] check update version beta alpha

### DIFF
--- a/backend/src/preferences.ts
+++ b/backend/src/preferences.ts
@@ -12,6 +12,7 @@ export class Preferences {
     remoteUIOverride: false,
     disableLocalNetwork: false,
     showNotifications: true,
+    allowPrerelease: false,
   }
 
   private file: JSONFile<IPreferences>

--- a/common/types.d.ts
+++ b/common/types.d.ts
@@ -486,6 +486,7 @@ declare global {
     remoteUIOverride?: boolean
     disableLocalNetwork?: boolean
     showNotifications?: boolean
+    allowPrerelease?: boolean
   }
 
   type SegmentContext = {

--- a/frontend/src/pages/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage/SettingsPage.tsx
@@ -23,7 +23,7 @@ import { Logo } from '../../components/Logo'
 import analyticsHelper from '../../helpers/analyticsHelper'
 
 export const SettingsPage: React.FC<{ singlePanel?: boolean }> = ({ singlePanel }) => {
-  const { showReports, os, installing, cliVersion, preferences, targetDevice, notOwner, remoteUI } = useSelector(
+  const { showReports, os, installing, cliVersion, preferences, targetDevice, notOwner, remoteUI, user } = useSelector(
     (state: ApplicationState) => ({
       showReports: state.auth.user?.email.includes('@remote.it'),
       os: state.backend.environment.os,
@@ -33,6 +33,7 @@ export const SettingsPage: React.FC<{ singlePanel?: boolean }> = ({ singlePanel 
       targetDevice: state.backend.device,
       notOwner: !!state.backend.device.uid && !getOwnDevices(state).find(d => d.id === state.backend.device.uid),
       remoteUI: isRemoteUI(state),
+      user: state.auth.user,
     })
   )
   const css = useStyles()
@@ -100,12 +101,22 @@ export const SettingsPage: React.FC<{ singlePanel?: boolean }> = ({ singlePanel 
           onClick={() => emit('preferences', { ...preferences, showNotifications: !preferences.showNotifications })}
         />
         {(os === 'mac' || os === 'windows') && (
-          <ListItemSetting
-            label="Auto update"
-            icon="chevron-double-up"
-            toggle={preferences.autoUpdate}
-            onClick={() => emit('preferences', { ...preferences, autoUpdate: !preferences.autoUpdate })}
-          />
+          <>
+            <ListItemSetting
+              label="Auto update"
+              icon="chevron-double-up"
+              toggle={preferences.autoUpdate}
+              onClick={() => emit('preferences', { ...preferences, autoUpdate: !preferences.autoUpdate })}
+            />
+            {user?.email.includes('@remote.it') && (
+              <ListItemSetting
+                label="Allow Prerelease"
+                icon="broadcast-tower"
+                toggle={preferences.allowPrerelease}
+                onClick={() => emit('preferences', { ...preferences, allowPrerelease: !preferences.allowPrerelease })}
+              />
+            )}
+          </>
         )}
         <ListItemSetting
           label="Open at login"

--- a/src/AutoUpdater.ts
+++ b/src/AutoUpdater.ts
@@ -28,6 +28,7 @@ export default class AppUpdater {
     })
 
     EventBus.on(EVENTS.preferences, ({ autoUpdate }: IPreferences) => {
+      autoUpdater.allowPrerelease = preferences.get().allowPrerelease || false
       if (autoUpdate !== this.autoUpdate) this.check(true)
       this.autoUpdate = !!autoUpdate
     })
@@ -52,6 +53,7 @@ export default class AppUpdater {
             Logger.error('LATEST VERSION ERROR', { error })
           }
         } else if (environment.isWindows || environment.isMac) {
+          Logger.info('CHECK FOR UPDATE')
           if (force || (this.nextCheck < Date.now() && preferences.get().autoUpdate)) {
             autoUpdater.checkForUpdatesAndNotify()
             this.nextCheck = Date.now() + AUTO_UPDATE_CHECK_INTERVAL


### PR DESCRIPTION
### Description

check-update version also using beta  and alpha

`semverCompare` avoid check version if the current version is alpha o beta

before to compare, this change is sending just version without `alpha` or `beta`

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Use a version alpha or beta newest than the last stable release
2. You should not see a modal to update

### Ticket

https://remoteit.atlassian.net/browse/DESK-1038
