### PR TITLE
[DESK-1071] avoid re share user

### DIFF
--- a/frontend/src/models/shares.ts
+++ b/frontend/src/models/shares.ts
@@ -70,7 +70,10 @@ export default createModel<RootModel>()({
     }) {
       const { device, emails, scripting, services, isNew } = infoUpdate
 
-      const newUsers: IUser[] = emails.map(email => ({ email, id: '', scripting }))
+      const sharedUsers = device.access.map(item => item.email)
+      const newUsers: IUser[] = emails
+        .map(email => ({ email, id: '', scripting }))
+        .filter(item => !sharedUsers.includes(item.email) && item)
       if (isNew) {
         const access = device.access.filter(i => emails.includes(i.email))
         device.access =


### PR DESCRIPTION
### Description

 avoid re-share user

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Sign in
2. Go to device service
3. Click share users
4. Add one that you had shared
4. You should not see error

### Ticket

https://remoteit.atlassian.net/browse/DESK-1071
