### PR TITLE
Fix name and icon for notification

### DIFF
--- a/src/ElectronApp.ts
+++ b/src/ElectronApp.ts
@@ -30,7 +30,7 @@ export default class ElectronApp {
     this.autoUpdater = new AutoUpdater()
     this.protocol = process.env.NODE_ENV === 'development' ? DEEP_LINK_PROTOCOL_DEV : DEEP_LINK_PROTOCOL
 
-    if (!this.requestSingleInstanceLock()) {
+    if (!this.app.requestSingleInstanceLock()) {
       Logger.warn('ANOTHER APP INSTANCE IS RUNNING. EXITING.')
       this.app.quit()
     }

--- a/src/ElectronApp.ts
+++ b/src/ElectronApp.ts
@@ -122,6 +122,7 @@ export default class ElectronApp {
   private createMainWindow = () => {
     d('Create main window')
     if (this.window) return
+    app.setAppUserModelId(process.execPath)
 
     this.window = new electron.BrowserWindow({
       width: 1280,

--- a/src/ElectronApp.ts
+++ b/src/ElectronApp.ts
@@ -30,7 +30,7 @@ export default class ElectronApp {
     this.autoUpdater = new AutoUpdater()
     this.protocol = process.env.NODE_ENV === 'development' ? DEEP_LINK_PROTOCOL_DEV : DEEP_LINK_PROTOCOL
 
-    if (!this.app.requestSingleInstanceLock()) {
+    if (!this.requestSingleInstanceLock()) {
       Logger.warn('ANOTHER APP INSTANCE IS RUNNING. EXITING.')
       this.app.quit()
     }
@@ -122,7 +122,7 @@ export default class ElectronApp {
   private createMainWindow = () => {
     d('Create main window')
     if (this.window) return
-    app.setAppUserModelId(process.execPath)
+    this.app.setAppUserModelId(process.execPath)
 
     this.window = new electron.BrowserWindow({
       width: 1280,


### PR DESCRIPTION
### Description

<!-- Describe, at a high level, what changes you made and why -->
So, when you will receive a toaster notification, you will see Remote.it app name and icon,

### Checklist

<!-- Please make sure all the boxes below are checked or removed if not relevant -->

- [ x ] This PR only contains one isolated change (bug fix, feature, etc) (yes, as far I know)
- [ x ] I have manually reviewed this PR to make sure only the files I intended to change were changed and nothing else

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Go on a Windows 10 computer
2. Put a shortcut of Electron.exe (in `node_modules\electron\dist\electron.exe`) in your start menu, then give him as name: "Remote.it" and as logo a Remote.it Logo
3. Start the app then open Devtools
4. Type
```js
new Notification("Test")
```
5. You should see as Notification name "Remote.it" and as logo, the logo of Remote.it

Thank you for making that awesome software :)
