### PR TITLE
[DESK-1081] connection port

### DIFF
--- a/frontend/src/buttons/ConnectButton/ConnectButton.tsx
+++ b/frontend/src/buttons/ConnectButton/ConnectButton.tsx
@@ -45,7 +45,7 @@ export const ConnectButton: React.FC<ConnectButtonProps> = ({
     } else {
       onClick && onClick()
       analyticsHelper.trackConnect('connectionInitiated', service)
-      connection = connection || newConnection(service)
+      connection = newConnection(service)
       connection?.public ? connections.proxyConnect(connection) : emit('service/connect', connection)
     }
   }


### PR DESCRIPTION
### Description

[DESK-1081] connection port default on reset

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. select your own device
2. select a service
3. edit the default port field
4. connect service
5. check under the connect button the address

### Ticket

https://remoteit.atlassian.net/browse/DESK-1081


[DESK-1081]: https://remoteit.atlassian.net/browse/DESK-1081