### PR TITLE
[DESK-1132] show name device in user logs

### DIFF
--- a/common/types.d.ts
+++ b/common/types.d.ts
@@ -400,6 +400,7 @@ declare global {
     target?: (IService | IDevice)[]
     users?: IUser[]
     action: string
+    devices?:{id?: number, name?: string}[]
   }
 
   interface IEventList {

--- a/frontend/src/components/EventList/EventMessage.tsx
+++ b/frontend/src/components/EventList/EventMessage.tsx
@@ -44,6 +44,7 @@ export function EventMessage({
 
     case EventType.device_share:
       const actor = item.actor?.email === loggedInUser?.email ? 'You' : item.actor?.email
+      const deviceName = device ? device.name : item.devices?.find((item, index) => index === 0)?.name
       const users = item.users && item.users.map(user => user.email || '(deleted)')
       const userList =
         users && users.length !== 1 ? users.slice(0, -1).join(', ') + ' and ' + users.slice(-1) : users && users[0]
@@ -52,26 +53,26 @@ export function EventMessage({
       if (item.shared) {
         message = (
           <>
-            {actor} shared <i>{device?.name}</i> and {item.scripting ? 'allowed' : 'restricted'} script execution with
+            {actor} shared <i>{deviceName}</i> and {item.scripting ? 'allowed' : 'restricted'} script execution with
             <b>{affected}</b>
           </>
         )
       } else if (ADD_EVENTS_ACTIONS.includes(item.action)) {
         message = (
           <>
-            {actor} shared <i>{device?.name}</i> with <b>{affected}</b>
+            {actor} shared <i>{deviceName}</i> with <b>{affected}</b>
           </>
         )
       } else if (actor === affected) {
         message = (
           <>
-            You left the shared device <i>{device?.name}</i>
+            You left the shared device <i>{deviceName}</i>
           </>
         )
       } else {
         message = (
           <>
-            {actor} removed sharing of <i>{device?.name}</i> from <b>{affected}</b>
+            {actor} removed sharing of <i>{deviceName}</i> from <b>{affected}</b>
           </>
         )
       }

--- a/frontend/src/components/EventList/EventMessage.tsx
+++ b/frontend/src/components/EventList/EventMessage.tsx
@@ -44,7 +44,7 @@ export function EventMessage({
 
     case EventType.device_share:
       const actor = item.actor?.email === loggedInUser?.email ? 'You' : item.actor?.email
-      const deviceName = device ? device.name : item.devices?.find((item, index) => index === 0)?.name
+      const deviceName = device ? device.name : item.devices?.length && item.devices[0]?.name
       const users = item.users && item.users.map(user => user.email || '(deleted)')
       const userList =
         users && users.length !== 1 ? users.slice(0, -1).join(', ') + ' and ' + users.slice(-1) : users && users[0]


### PR DESCRIPTION
### Description[DESK-1132] show name device in user logs


### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Sign in
2. Go to user logs
3. . You should see correctly the logs

### Ticket

https://remoteit.atlassian.net/browse/DESK-1132


[DESK-1132]: https://remoteit.atlassian.net/browse/DESK-1132