### PR TITLE
Fixing Notification Name when app is packaged

### DIFF
--- a/src/ElectronApp.ts
+++ b/src/ElectronApp.ts
@@ -122,7 +122,7 @@ export default class ElectronApp {
   private createMainWindow = () => {
     d('Create main window')
     if (this.window) return
-    this.app.setAppUserModelId(process.execPath)
+    this.app.setAppUserModelId('it.remote.desktop')
 
     this.window = new electron.BrowserWindow({
       width: 1280,


### PR DESCRIPTION
### Description

<!-- Describe, at a high level, what changes you made and why -->
When you package your app, if you got a notification on a windows 10, it will show as app name "it.remote.desktop". This is a fix for this bug

### Checklist

<!-- Please make sure all the boxes below are checked or removed if not relevant -->
- [x] This PR only contains one isolated change (bug fix, feature, etc)
- [x] I have manually reviewed this PR to make sure only the files I intended to change were changed and nothing else

### Test plan

<!-- List what things need to be tested manually to ensure this change is properly tested -->

1. Package your app for Windows
2. Run the packaged app from a Windows computer
3. Make a notification using devtools
4. See the changes
