### PR TITLE
DESK-1266 Clear service form error message on init

### DIFF
--- a/frontend/src/components/Attributes.tsx
+++ b/frontend/src/components/Attributes.tsx
@@ -141,7 +141,7 @@ export const attributes: Attribute[] = [
     label: 'Owner',
     value: ({ device }) => device?.owner.email,
   }),
-  new DeviceAttribute({
+  new Attribute({
     id: 'access',
     label: 'Access',
     value: ({ device }) =>

--- a/frontend/src/components/ServiceForm/ServiceForm.tsx
+++ b/frontend/src/components/ServiceForm/ServiceForm.tsx
@@ -41,6 +41,7 @@ export const ServiceForm: React.FC<Props> = ({
     isValid: state.backend.reachablePort,
   }))
   const initForm = () => {
+    setError(undefined)
     const defaultAppType = findType(applicationTypes, target.type)
     return {
       hostname: service?.host || target.hostname,


### PR DESCRIPTION
1. Clear service form error message on init. 
2. Also only show Access attributes in device list

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/DESK-1266>
