### PR TITLE
DESK-1438 DESK-1439 DESK-1440 DESK-1442 Refresh data after creating a new org

### DIFF
--- a/frontend/src/components/PlanCheckout.tsx
+++ b/frontend/src/components/PlanCheckout.tsx
@@ -45,8 +45,10 @@ export const PlanCheckout: React.FC<Props> = ({ plans, form, license, onChange, 
     onChange({ ...form, priceId })
   }
 
+  console.log('license', license)
   const onSubmit = () => {
-    if (license?.plan?.billing) dispatch.plans.updateSubscription(form)
+    console.log('submit license', license)
+    if (license?.subscription) dispatch.plans.updateSubscription(form)
     else dispatch.plans.subscribe(form)
   }
 

--- a/frontend/src/models/organization.ts
+++ b/frontend/src/models/organization.ts
@@ -223,11 +223,10 @@ export default createModel<RootModel>()({
       let organization = getOrganization(state)
       await dispatch.organization.setActive({ ...params, id: organization.id || state.auth.user?.id })
       const result = await graphQLSetOrganization(params)
-      if (result === 'ERROR') {
-        await dispatch.organization.fetch()
-      } else if (!organization.id) {
-        dispatch.ui.set({ successMessage: 'Your organization has been created.' })
+      if (result !== 'ERROR') {
+        if (!organization.id) dispatch.ui.set({ successMessage: 'Your organization has been created.' })
       }
+      await dispatch.organization.fetch()
     },
 
     async setSAML(params: { enabled: boolean; metadata?: string }) {

--- a/frontend/src/models/plans.ts
+++ b/frontend/src/models/plans.ts
@@ -148,8 +148,7 @@ export default createModel<RootModel>()({
           dispatch.plans.set({ purchasing: undefined })
         }
       }
-      setTimeout(dispatch.ui.refreshAll, 5 * 1000)
-      setTimeout(() => dispatch.plans.set({ purchasing: undefined }), 30 * 1000)
+      setTimeout(() => dispatch.plans.set({ purchasing: undefined }), 60 * 1000)
       console.log('UPDATE SUBSCRIPTION', { priceId, quantity, result })
     },
 
@@ -173,6 +172,7 @@ export default createModel<RootModel>()({
 
     async updated() {
       await dispatch.plans.fetch()
+      await dispatch.organization.fetch()
       dispatch.plans.set({ purchasing: undefined, updating: undefined })
       dispatch.ui.set({ successMessage: 'Subscription updated.' })
     },
@@ -233,7 +233,8 @@ export function getLicenses(state: ApplicationState, accountId?: string) {
 export function getFreeLicenses(state: ApplicationState) {
   if (isEnterprise(state)) return 1
   const purchased = selectRemoteitLicense(state)?.quantity || 0
-  const used = 1 + getOrganization(state).members.reduce((sum, m) => sum + (m.license === 'LICENSED' ? 1 : 0), 0)
+  const used = getOrganization(state).members.reduce((sum, m) => sum + (m.license === 'LICENSED' ? 1 : 0), 1)
+  console.log('purchased', purchased, 'used', used)
   return Math.max(purchased - used, 0)
 }
 

--- a/frontend/src/pages/OrganizationAddPage.tsx
+++ b/frontend/src/pages/OrganizationAddPage.tsx
@@ -38,8 +38,6 @@ export const OrganizationAddPage = () => {
     analyticsHelper.page('AccountLinkPage')
   }, [])
 
-  console.log('ROLE', roleId, organization.roles)
-
   const exit = () => history.push(location.pathname.replace('/share', ''))
   const add = () => {
     dispatch.organization.setMembers(

--- a/frontend/src/services/cloudController.ts
+++ b/frontend/src/services/cloudController.ts
@@ -310,7 +310,7 @@ class CloudController {
 
       case 'LICENSE_UPDATED':
         this.log('LICENSE UPDATED EVENT', event)
-        plans.updated()
+        setTimeout(plans.updated, 2000) // because event comes in before plan is fully updated
         break
     }
     return event


### PR DESCRIPTION
### Description

Refresh org data so we have the roles on a new org.
Fix the existing subscription detection so that new users can subscribe
wait for plan to be fully update after purchase update

### Ticket

<!-- Add a link to the ticket(s) related to this PR -->

<https://remoteit.atlassian.net/browse/DESK-1438>
<https://remoteit.atlassian.net/browse/DESK-1439>
<https://remoteit.atlassian.net/browse/DESK-1440>
<https://remoteit.atlassian.net/browse/DESK-1442>
