### PR TITLE
GQL-252 DESK-1613 test bugs

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remoteit-headless",
-  "version": "3.12.0-beta.2",
+  "version": "3.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "remoteit-headless",
-      "version": "3.12.0-beta.2",
+      "version": "3.12.1",
       "bundleDependencies": [
         "@airbrake/node",
         "@types/plist",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteit-headless",
-  "version": "3.12.0-beta.2",
+  "version": "3.12.1",
   "private": true,
   "main": "build/index.js",
   "scripts": {

--- a/backend/src/ConnectionPool.ts
+++ b/backend/src/ConnectionPool.ts
@@ -81,7 +81,11 @@ export default class ConnectionPool {
       if (connection.params.host === IP_PRIVATE && preferences.get().useCertificate) {
         if (!connection.params.error) {
           Logger.warn('CERTIFICATE HOSTNAME ERROR', { connection: connection.params })
-          connection.error(new Error('Connection certificate error, unable to use custom hostname.'))
+          connection.error(
+            new Error(
+              'Connection certificate error, unable to use custom hostname. If this continues turn off "Named Connections" in the Application Settings page.'
+            )
+          )
         }
         update = true
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remoteit-desktop-frontend",
-  "version": "3.12.0-beta.2",
+  "version": "3.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "remoteit-desktop-frontend",
-      "version": "3.12.0-beta.2",
+      "version": "3.12.1",
       "dependencies": {
         "@aws-amplify/auth": "^4.1.1",
         "@date-io/date-fns": "^1.3.13",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteit-desktop-frontend",
-  "version": "3.12.0-beta.2",
+  "version": "3.12.1",
   "private": true,
   "main": "src/server/initialize.js",
   "scripts": {

--- a/frontend/src/buttons/AddUserButton/AddUserButton.tsx
+++ b/frontend/src/buttons/AddUserButton/AddUserButton.tsx
@@ -8,7 +8,7 @@ type Props = IconProps & { to: string; hide?: boolean; children?: React.ReactNod
 export const AddUserButton: React.FC<Props> = ({ to, hide, children, ...props }) => {
   if (hide) return null
   return (
-    <Tooltip title="Share">
+    <Tooltip title="Share to guest">
       <IconButton to={to} component={Link}>
         <Icon name="arrow-up-from-bracket" size="md" {...props} />
         {children}

--- a/frontend/src/buttons/ErrorButton/ErrorButton.tsx
+++ b/frontend/src/buttons/ErrorButton/ErrorButton.tsx
@@ -1,23 +1,22 @@
 import React from 'react'
-import { Tooltip, IconButton } from '@mui/material'
-import { Icon } from '../../components/Icon'
+import { IconButton } from '../IconButton'
 
-type Props = { connection?: IConnection; onClick?: () => void; visible: boolean; className?: string }
+type Props = { connection?: IConnection; onClick?: () => void; visible: boolean }
 
-export const ErrorButton: React.FC<Props> = ({ connection, onClick, visible, className }) => {
+export const ErrorButton: React.FC<Props> = ({ connection, onClick, visible }) => {
   if (!connection || !connection.error?.message) return null
 
   return (
-    <Tooltip title={visible ? 'Hide error' : 'Show error'} className={className}>
-      <IconButton
-        onClick={event => {
-          event.stopPropagation()
-          onClick && onClick()
-        }}
-        size="large"
-      >
-        <Icon name="exclamation-triangle" color="danger" size="md" fixedWidth />
-      </IconButton>
-    </Tooltip>
+    <IconButton
+      onClick={event => {
+        event.stopPropagation()
+        onClick && onClick()
+      }}
+      title={visible ? 'Hide error' : 'Show error'}
+      icon="exclamation-triangle"
+      size="md"
+      color="danger"
+      inlineLeft
+    />
   )
 }

--- a/frontend/src/components/Connect.tsx
+++ b/frontend/src/components/Connect.tsx
@@ -5,7 +5,6 @@ import { useSelector, useDispatch } from 'react-redux'
 import { useParams, useLocation } from 'react-router-dom'
 import { getDeviceModel } from '../models/accounts'
 import { windowOpen } from '../services/Browser'
-import { selectById } from '../models/devices'
 import { PortSetting } from './PortSetting'
 import { NameSetting } from './NameSetting'
 import { makeStyles } from '@mui/styles'
@@ -13,7 +12,6 @@ import { RouteSetting } from './RouteSetting'
 import { PublicSetting } from './PublicSetting'
 import { TimeoutSetting } from './TimeoutSetting'
 import { LicensingNotice } from './LicensingNotice'
-import { selectConnection } from '../helpers/connectionHelper'
 import { ConnectionDetails } from './ConnectionDetails'
 import { ConnectionErrorMessage } from './ConnectionErrorMessage'
 import { ConnectionLogSetting } from './ConnectionLogSetting'
@@ -35,7 +33,13 @@ import { Gutters } from './Gutters'
 import { spacing } from '../styling'
 import { Notice } from './Notice'
 
-export const Connect: React.FC = () => {
+type Props = {
+  service?: IService
+  device?: IDevice
+  connection: IConnection
+}
+
+export const Connect: React.FC<Props> = ({ service, device, connection }) => {
   const css = useStyles()
   const location = useLocation<{
     autoConnect?: boolean
@@ -43,24 +47,20 @@ export const Connect: React.FC = () => {
     autoCopy?: boolean
     autoFeedback?: boolean
   }>()
-  const { deviceID, serviceID, sessionID } = useParams<{ deviceID?: string; serviceID?: string; sessionID?: string }>()
+  const { deviceID, sessionID } = useParams<{ deviceID?: string; sessionID?: string }>()
   const [showError, setShowError] = useState<boolean>(true)
   const dispatch = useDispatch<Dispatch>()
-  const { service, device, connection, session, accordion, ownDevice } = useSelector((state: ApplicationState) => {
-    const [service, device] = selectById(state, serviceID)
-    return {
-      service,
-      device,
-      ownDevice: device?.thisDevice && device?.owner.id === state.user.id,
-      connection: selectConnection(state, service),
-      session: state.sessions.all.find(s => s.id === sessionID),
-      fetching: getDeviceModel(state).fetching,
-      accordion: state.ui.accordion,
-    }
-  })
+  const { session, accordion, ownDevice } = useSelector((state: ApplicationState) => ({
+    ownDevice: device?.thisDevice && device?.owner.id === state.user.id,
+    session: state.sessions.all.find(s => s.id === sessionID),
+    fetching: getDeviceModel(state).fetching,
+    accordion: state.ui.accordion,
+  }))
+
   const accordionConfig = connection?.enabled ? 'configConnected' : 'config'
 
   useEffect(() => {
+    // FIXME - move this up to the router level - for connection display now
     const id = connection?.deviceID || deviceID
     if (!device && id) dispatch.devices.fetchSingle({ id, hidden: true })
   }, [deviceID])

--- a/frontend/src/components/DeviceHeaderMenu.tsx
+++ b/frontend/src/components/DeviceHeaderMenu.tsx
@@ -3,7 +3,7 @@ import { DeviceContext } from '../services/Context'
 import { Typography } from '@mui/material'
 import { attributeName } from '../shared/nameHelper'
 import { ListItemLocation } from './ListItemLocation'
-import { UnauthorizedPage } from '../pages/UnauthorizedPage'
+import { LoadingMessage } from './LoadingMessage'
 import { DeviceTagEditor } from './DeviceTagEditor'
 import { ListHorizontal } from './ListHorizontal'
 import { DeviceConnectMenu } from './DeviceConnectMenu'
@@ -17,7 +17,7 @@ import { Title } from './Title'
 
 export const DeviceHeaderMenu: React.FC<{ header?: any; children?: React.ReactNode }> = ({ header, children }) => {
   const { device } = useContext(DeviceContext)
-  if (!device) return <UnauthorizedPage />
+  if (!device) return <LoadingMessage />
 
   return (
     <Container

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -89,13 +89,7 @@ export const Header: React.FC<{ breadcrumbs?: boolean }> = ({ breadcrumbs }) => 
                 setShowSearch(true)
                 setTimeout(() => inputRef.current?.focus(), 20)
               }}
-            >
-              {device && (
-                <Typography variant="caption" color="textSecondary">
-                  {attributeName(device)}
-                </Typography>
-              )}
-            </IconButton>
+            />
           )}
           {(!!showSearch || searched) && <GlobalSearch inputRef={inputRef} onClose={() => setShowSearch(false)} />}
         </Title>

--- a/frontend/src/components/NetworkListItem.tsx
+++ b/frontend/src/components/NetworkListItem.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import reactStringReplace from 'react-string-replace'
 import { makeStyles } from '@mui/styles'
 import { useLocation } from 'react-router-dom'
 import { selectConnection } from '../helpers/connectionHelper'

--- a/frontend/src/components/NetworksAccordion.tsx
+++ b/frontend/src/components/NetworksAccordion.tsx
@@ -66,9 +66,8 @@ export const NetworksAccordion: React.FC<Props> = ({ expanded, device, service, 
             <Tooltip
               title={
                 <>
-                  You must be the device owner or
-                  <br />
-                  manager to add it to a network.
+                  {!device?.permissions.includes('MANAGE') && 'You are not a manager of this device.'}
+                  {device?.shared && 'You can not add a device shared to you.'}
                 </>
               }
               placement="left"

--- a/frontend/src/components/ServiceHeaderMenu.tsx
+++ b/frontend/src/components/ServiceHeaderMenu.tsx
@@ -7,7 +7,7 @@ import { LicensingNotice } from './LicensingNotice'
 import { ListItemLocation } from './ListItemLocation'
 import { Typography } from '@mui/material'
 import { DeviceOptionMenu } from './DeviceOptionMenu'
-import { UnauthorizedPage } from '../pages/UnauthorizedPage'
+import { LoadingMessage } from './LoadingMessage'
 import { AddUserButton } from '../buttons/AddUserButton'
 import { Container } from './Container'
 import { UsersTab } from './UsersTab'
@@ -23,7 +23,7 @@ export const ServiceHeaderMenu: React.FC<{
 }> = ({ device, service, footer, backgroundColor, children }) => {
   const { serviceID = '' } = useParams<{ deviceID: string; serviceID: string }>()
 
-  if (!service || !device) return <UnauthorizedPage />
+  if (!service || !device) return <LoadingMessage />
 
   return (
     <Container

--- a/frontend/src/components/SharedUsersLists.tsx
+++ b/frontend/src/components/SharedUsersLists.tsx
@@ -43,8 +43,13 @@ export const SharedUsersLists: React.FC<Props> = ({ device, network, connected =
           or
         </Typography>
         {hasOrganization ? (
-          <IconButton icon="user-plus" to="/organization/share" size="md">
-            <Typography variant="body2"> &nbsp;&nbsp; Add a member</Typography>
+          <IconButton
+            icon="user-plus"
+            to="/organization/share"
+            size="md"
+            disabled={!instance?.permissions.includes('ADMIN')}
+          >
+            <Typography variant="body2"> &nbsp;&nbsp; Add an organization member</Typography>
           </IconButton>
         ) : (
           <IconButton icon="industry-alt" to="/organization" size="md">

--- a/frontend/src/components/SidebarNav.tsx
+++ b/frontend/src/components/SidebarNav.tsx
@@ -6,18 +6,11 @@ import { selectAnnouncements } from '../models/announcements'
 import { useSelector, useDispatch } from 'react-redux'
 import { ApplicationState, Dispatch } from '../store'
 import { List, ListItemSecondaryAction, Tooltip, Divider, Chip } from '@mui/material'
-import { selectEnabledConnections } from '../helpers/connectionHelper'
+import { selectEnabledConnections, selectActiveCount } from '../helpers/connectionHelper'
 import { ListItemLocation } from './ListItemLocation'
 import { ListItemLink } from './ListItemLink'
 import { isRemoteUI } from '../helpers/uiHelper'
 import { spacing } from '../styling'
-
-function selectActiveCount(state: ApplicationState, connections: IConnection[]): string[] {
-  const sessions = state.sessions.all.map(s => s.target.id)
-  const connected = connections.filter(c => c.connected).map(c => c.id)
-  const unique = new Set(sessions.concat(connected))
-  return Array.from(unique)
-}
 
 export const SidebarNav: React.FC = () => {
   const { unreadAnnouncements, connections, networks, active, devices, remoteUI } = useSelector(

--- a/frontend/src/helpers/connectionHelper.ts
+++ b/frontend/src/helpers/connectionHelper.ts
@@ -24,6 +24,13 @@ export function connectionState(instance?: IService | IDevice, connection?: ICon
   return 'disconnected'
 }
 
+export function selectActiveCount(state: ApplicationState, connections: IConnection[]): string[] {
+  const sessions = state.sessions.all.map(s => s.target.id)
+  const connected = connections.filter(c => c.connected).map(c => c.id)
+  const unique = new Set(sessions.concat(connected))
+  return Array.from(unique)
+}
+
 export function findLocalConnection(state: ApplicationState, id: string, sessionId: string | undefined) {
   return state.connections.all.find(c => c.id === id && (c.sessionId === sessionId || c.connecting))
 }

--- a/frontend/src/models/devices.ts
+++ b/frontend/src/models/devices.ts
@@ -512,7 +512,10 @@ export function selectDeviceByAccount(state: ApplicationState, deviceId?: string
 }
 
 export function selectById(state: ApplicationState, id?: string) {
-  return findService(getAllDevices(state), id)
+  const accountId = getActiveAccountId(state)
+  const accountDevices = getDevices(state, accountId)
+  const result = findService(accountDevices, id)
+  return result[0] ? result : findService(getAllDevices(state), id)
 }
 
 export function findService(devices: IDevice[], id?: string) {

--- a/frontend/src/pages/ConnectionPage.tsx
+++ b/frontend/src/pages/ConnectionPage.tsx
@@ -65,7 +65,7 @@ export const ConnectionPage: React.FC = () => {
         </>
       }
     >
-      <Connect />
+      <Connect service={service} device={device} connection={connection} />
       <Gutters size="md">
         <AccordionMenuItem
           gutters

--- a/frontend/src/pages/DevicePage.tsx
+++ b/frontend/src/pages/DevicePage.tsx
@@ -24,11 +24,7 @@ import { TestUI } from '../components/TestUI'
 import { Title } from '../components/Title'
 import { fontSizes } from '../styling'
 
-type Props = {
-  device?: IDevice
-}
-
-export const DevicePage: React.FC<Props> = () => {
+export const DevicePage: React.FC = () => {
   const { connections, device } = useContext(DeviceContext)
   const location = useLocation()
   const history = useHistory()

--- a/frontend/src/pages/ServiceConnectPage.tsx
+++ b/frontend/src/pages/ServiceConnectPage.tsx
@@ -1,12 +1,14 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { useParams } from 'react-router-dom'
 import { useSelector } from 'react-redux'
+import { DeviceContext } from '../services/Context'
 import { ApplicationState } from '../store'
 import { ServiceHeaderMenu } from '../components/ServiceHeaderMenu'
 import { selectConnection } from '../helpers/connectionHelper'
 import { Connect } from '../components/Connect'
 
-export const ServiceConnectPage: React.FC<{ device?: IDevice }> = ({ device }) => {
+export const ServiceConnectPage: React.FC = () => {
+  const { device } = useContext(DeviceContext)
   const { serviceID } = useParams<{ serviceID: string }>()
   const service = device?.services.find(s => s.id === serviceID)
   const { connection } = useSelector((state: ApplicationState) => ({
@@ -21,7 +23,7 @@ export const ServiceConnectPage: React.FC<{ device?: IDevice }> = ({ device }) =
       service={service}
       backgroundColor={connection.enabled ? 'primaryBackground' : 'grayLighter'}
     >
-      <Connect />
+      <Connect service={service} device={device} connection={connection} />
     </ServiceHeaderMenu>
   )
 }

--- a/frontend/src/pages/SharePage/SharePage.tsx
+++ b/frontend/src/pages/SharePage/SharePage.tsx
@@ -21,11 +21,14 @@ type IParams = { userID: string; serviceID: string; deviceID: string }
 export const SharePage: React.FC = () => {
   const { userID = '', serviceID = '', deviceID = '' } = useParams<IParams>()
   const { shares, organization } = useDispatch<Dispatch>()
-  const { device, guests, deleting } = useSelector((state: ApplicationState) => ({
-    device: selectDevice(state, deviceID),
-    guests: getOrganization(state).guests,
-    deleting: state.shares.deleting,
-  }))
+  const { device, guests, deleting } = useSelector((state: ApplicationState) => {
+    const device = selectDevice(state, deviceID)
+    return {
+      device,
+      guests: device ? device.access : (getOrganization(state).guests as IUserRef[]),
+      deleting: state.shares.deleting,
+    }
+  })
   const location = useLocation()
   const history = useHistory()
   const css = useStyles()
@@ -47,7 +50,7 @@ export const SharePage: React.FC = () => {
   const handleChange = (emails: string[]) => {
     shares.selectContacts(emails)
   }
-
+  console.log('SHARE PAGE', { email, guests, guest, device })
   return (
     <Container
       header={

--- a/frontend/src/routers/DeviceRouter.tsx
+++ b/frontend/src/routers/DeviceRouter.tsx
@@ -57,7 +57,7 @@ export const DeviceRouter: React.FC<{ layout: ILayout }> = ({ layout }) => {
   return (
     <DeviceContext.Provider value={{ device, connections }}>
       <DynamicPanel
-        primary={<DevicePage device={device} />}
+        primary={<DevicePage />}
         secondary={
           <Switch>
             <Route path="/devices/:deviceID/add/scan">
@@ -106,7 +106,7 @@ export const DeviceRouter: React.FC<{ layout: ILayout }> = ({ layout }) => {
               <LanSharePage />
             </Route>
             <Route path={['/devices/:deviceID/:serviceID/connect', '/devices/:deviceID/:serviceID']}>
-              <ServiceConnectPage device={device} />
+              <ServiceConnectPage />
             </Route>
           </Switch>
         }

--- a/installer.nsh
+++ b/installer.nsh
@@ -2,7 +2,7 @@
 !include x64.nsh
 !include LogicLib.nsh
 !define REMOTEIT_BACKUP "$PROFILE\AppData\Local\remoteit-backup"
-!define PKGVERSION "3.12.0-beta.2"
+!define PKGVERSION "3.12.1"
 
 !macro customInit
     Var /GLOBAL path_i

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remoteit",
-  "version": "3.12.0-beta.2",
+  "version": "3.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "remoteit",
-      "version": "3.12.0-beta.2",
+      "version": "3.12.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -32,7 +32,7 @@
     },
     "backend": {
       "name": "remoteit-headless",
-      "version": "3.12.0-beta.2",
+      "version": "3.12.1",
       "bundleDependencies": [
         "@airbrake/node",
         "@types/plist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteit",
-  "version": "3.12.0-beta.2",
+  "version": "3.12.1",
   "private": true,
   "main": "build/index.js",
   "description": "remote.it cross platform desktop application for creating and hosting connections",


### PR DESCRIPTION
- GQL-252 get device access users as well as organization guests
- DESK-1613 disable adding organization member unless you have admin permission
- Remove device name from header
- Update share button to say Share to guest
- Change display of unauthorized if device not loaded to loading screen
- Update active connection counting logic
- Ensure connection device data is pulled from the active account
- Improved connection certificate error message
- Improved details why you can't add a service to a network