### PR TITLE
3.20.1

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remoteit-headless",
-  "version": "3.20.0-alpha.0",
+  "version": "3.20.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "remoteit-headless",
-      "version": "3.20.0-alpha.0",
+      "version": "3.20.1",
       "bundleDependencies": [
         "@airbrake/node",
         "axios",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteit-headless",
-  "version": "3.20.0-alpha.0",
+  "version": "3.20.1",
   "private": true,
   "main": "build/index.js",
   "scripts": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remoteit-desktop-frontend",
-  "version": "3.20.0-alpha.0",
+  "version": "3.20.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "remoteit-desktop-frontend",
-      "version": "3.20.0-alpha.0",
+      "version": "3.20.1",
       "dependencies": {
         "@airbrake/browser": "^2.1.8",
         "@aws-amplify/auth": "^5.3.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteit-desktop-frontend",
-  "version": "3.20.0-alpha.0",
+  "version": "3.20.1",
   "private": true,
   "main": "src/server/initialize.js",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remoteit",
-  "version": "3.20.0-alpha.0",
+  "version": "3.20.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "remoteit",
-      "version": "3.20.0-alpha.0",
+      "version": "3.20.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -27,7 +27,7 @@
     },
     "backend": {
       "name": "remoteit-headless",
-      "version": "3.20.0-alpha.0",
+      "version": "3.20.1",
       "bundleDependencies": [
         "@airbrake/node",
         "axios",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remoteit",
-  "version": "3.20.0-alpha.0",
+  "version": "3.20.1",
   "private": true,
   "main": "build/index.js",
   "description": "Remote.It cross platform desktop application for creating and hosting connections",


### PR DESCRIPTION
### Updates
- Added modal display for restore command or code copying
- Renamed 'start' button to 'connect' button on desktop
- Updated hostname error

### Fixes
- Fixed attributes display on device list
- Fixed owner role display being overwritten by guest
- Fixed long device list names not being contained
- Fixed share unshare event icons
- Improved columns button modified state
- Fully load device before launching

### Includes
- remoteit `v3.0.33`
- connectd `v4.18.2`
