### PR TITLE
fix(scripts): make StringEntry argument multiline

### DIFF
--- a/frontend/src/components/ArgumentsValueForm.tsx
+++ b/frontend/src/components/ArgumentsValueForm.tsx
@@ -89,6 +89,8 @@ const ArgumentInput: React.FC<ArgumentInputProps> = ({ argument, value, onChange
       return (
         <TextField
           fullWidth
+          multiline
+          maxRows={20}
           label={name}
           value={value}
           onChange={e => onChange(e.target.value)}


### PR DESCRIPTION
## Summary
- Script argument **Text Input** (`StringEntry`) now uses a `multiline` TextField that auto-expands as text is entered (up to 20 rows, then scrolls), matching the Service Description field pattern.
- Fixes inability to paste multi-line content like PEM keys — the previous single-line `<input>` stripped newlines on paste.

Note: there is no frontend length cap on argument values; if users still hit a ceiling, the limit lives server-side on the `setJob` mutation's `ArgumentInput.value`.

## Test plan
- [ ] Open a script with a Text Input argument and verify the field grows as you type multiple lines
- [ ] Paste a PEM key and confirm newlines are preserved
- [ ] Run the job and confirm the multi-line value is delivered intact