### PR TITLE
fix(roles): prevent new role from inheriting system flag from previous role

### DIFF
--- a/frontend/src/pages/OrganizationRolePage.tsx
+++ b/frontend/src/pages/OrganizationRolePage.tsx
@@ -41,7 +41,7 @@ export const OrganizationRolePage: React.FC = () => {
   }
 
   useEffect(() => {
-    changeForm(role)
+    setForm(role)
   }, [roleID])
 
   return (


### PR DESCRIPTION
## Summary
- When navigating from a system role (OWNER/GUEST) to the add-role page, the form-reset effect was using `changeForm(role)` which merges (`{...form, ...role}`). Since `DEFAULT_ROLE` has no `system` key, the previous role's `system: true` survived the merge and was sent through the optimistic update — making the new role appear as a locked system role until a refresh.
- Replace the merge with a direct `setForm(role)` so the form is fully reset on `roleID` change.

## Test plan
- [ ] Navigate to a system role (Owner/Guest), then click + to add a new role
- [ ] Save the new role and confirm it appears as an editable custom role (not locked) without needing a refresh