### PR TITLE
fix(launch): route Windows terminal through Sysnative cmd under WOW64

### DIFF
--- a/electron/src/backend/launch.ts
+++ b/electron/src/backend/launch.ts
@@ -17,7 +17,15 @@ export default async function launch(command: string, type: 'TERMINAL' | 'SCRIPT
     } else if (environment.isLinux) {
       command = `gnome-terminal -- /bin/bash -c '${command}; read'`
     } else {
-      command = `start cmd /k ${command.replace('start cmd /k', '')}`
+      // When the 32-bit (ia32) build runs on 64-bit Windows, WOW64 redirects
+      // C:\Windows\System32 to SysWOW64 — which lacks OpenSSH and other native
+      // tools. Spawning cmd.exe via the Sysnative alias gives us the host's
+      // native cmd, so PATH lookup resolves the real System32 binaries.
+      const cmd =
+        process.env.PROCESSOR_ARCHITEW6432 && process.env.SystemRoot
+          ? `"${process.env.SystemRoot}\\Sysnative\\cmd.exe"`
+          : 'cmd'
+      command = `start "" ${cmd} /k ${command.replace('start cmd /k', '')}`
     }
   }
 


### PR DESCRIPTION
## Summary
Resolves the support ticket where launching an SSH connection from the Terminal launch method on Windows fails with `'ssh' is not recognized as an internal or external command`.

## Root cause
The desktop ships three Windows builds (`ia32`, `x64`, `arm64`). The **32-bit (ia32) build** running on a 64-bit Windows host runs under WOW64, which silently redirects `C:\Windows\System32` → `C:\Windows\SysWOW64`. Native Windows tools like OpenSSH live in the real `System32\OpenSSH\` and have no SysWOW64 counterpart, so any PATH-resolved `ssh` lookup from a 32-bit child of the desktop fails. The 64-bit and arm64 builds are unaffected.

## Fix
Rather than embed a brittle hard-coded path in the user-visible launch template (which would only work for one architecture and would be cosmetically ugly besides), keep the template as the simple `ssh [username]@[host] -p [port]` and fix the launcher itself.

When TERMINAL launches on Windows, [`launch.ts`](electron/src/backend/launch.ts) now detects WOW64 via `process.env.PROCESSOR_ARCHITEW6432` (set **only** under WOW64) and, when set, spawns the host's native `cmd.exe` via the `Sysnative` alias. The native cmd resolves the real `System32` and PATH lookups for `ssh` (and any other native tool) work normally. For the `x64` and `arm64` builds, `PROCESSOR_ARCHITEW6432` is unset and behavior is unchanged (`start cmd /k ...`).

## Why not change the template
- A `Sysnative\OpenSSH\ssh.exe` template only works under WOW64 — `Sysnative` is **not** a valid alias from native 64-bit / arm64 processes, so it would break the other two Windows builds.
- Existing users with custom templates would not pick up the change anyway.
- The redirector is a launch-time concern, not a connection-config concern.

## Test plan
- [ ] **ia32 build on Windows 11 x64** — launch a SSH service via Terminal; verify a terminal window opens and `ssh` runs (this is the broken case in the ticket).
- [ ] **x64 build on Windows 11 x64** — same flow; verify nothing regressed (no Sysnative path in the spawned command).
- [ ] **arm64 build on Windows 11 ARM64** — same flow; verify nothing regressed.
- [ ] In each build, verify the spawned cmd window's title and behavior are unchanged from before (note: the 32-bit case now uses `start ""` to give an empty title for the explicit cmd path).