### PR TITLE
[codex] Fix 32-bit Windows SSH launch path

### DIFF
--- a/electron/src/backend/environment.ts
+++ b/electron/src/backend/environment.ts
@@ -43,7 +43,7 @@ export class Environment {
     this.isPiZero = detectRPi() && process.config.variables.arm_version === '6'
     this.isPi = detectRPi()
     this.isWindows = os.platform() === 'win32'
-    this.isWindows32 = this.isWindows && os.arch() !== 'x64'
+    this.isWindows32 = this.isWindows && os.arch() === 'ia32'
     this.isMac = os.platform() === 'darwin'
     this.isLinux = os.platform() === 'linux'
     this.isArmLinux = this.isLinux && os.arch() === 'arm64'

--- a/electron/src/backend/launch.test.ts
+++ b/electron/src/backend/launch.test.ts
@@ -1,0 +1,40 @@
+import {
+  buildWindowsTerminalCommand,
+  resolveWindowsTerminalCommand,
+  WINDOWS_32_BIT_OPENSSH,
+} from './launch'
+
+describe('backend/launch', () => {
+  describe('resolveWindowsTerminalCommand', () => {
+    test('uses Sysnative OpenSSH for plain ssh commands from 32-bit Windows', () => {
+      const command = resolveWindowsTerminalCommand('ssh user@example.com -p 2222', true)
+
+      expect(command).toBe(`${WINDOWS_32_BIT_OPENSSH} user@example.com -p 2222`)
+    })
+
+    test('uses Sysnative OpenSSH for plain ssh.exe commands from 32-bit Windows', () => {
+      const command = resolveWindowsTerminalCommand('ssh.exe user@example.com -p 2222', true)
+
+      expect(command).toBe(`${WINDOWS_32_BIT_OPENSSH} user@example.com -p 2222`)
+    })
+
+    test('does not rewrite other commands', () => {
+      expect(resolveWindowsTerminalCommand('ssh_config [User]', true)).toBe('ssh_config [User]')
+      expect(resolveWindowsTerminalCommand('plink user@example.com -P 2222', true)).toBe('plink user@example.com -P 2222')
+    })
+
+    test('does not rewrite 64-bit Windows commands', () => {
+      const command = 'ssh user@example.com -p 2222'
+
+      expect(resolveWindowsTerminalCommand(command, false)).toBe(command)
+    })
+  })
+
+  describe('buildWindowsTerminalCommand', () => {
+    test('normalizes existing cmd wrappers before applying the 32-bit ssh fix', () => {
+      const command = buildWindowsTerminalCommand('start cmd /k ssh user@example.com -p 2222', true)
+
+      expect(command).toBe(`start cmd /k ${WINDOWS_32_BIT_OPENSSH} user@example.com -p 2222`)
+    })
+  })
+})

--- a/electron/src/backend/launch.ts
+++ b/electron/src/backend/launch.ts
@@ -5,6 +5,22 @@ import EventBus from './EventBus'
 import Command from './Command'
 import environment from './environment'
 
+export const WINDOWS_32_BIT_OPENSSH = '%WINDIR%\\Sysnative\\OpenSSH\\ssh.exe'
+
+export function resolveWindowsTerminalCommand(command: string, isWindows32 = environment.isWindows32) {
+  if (!isWindows32) return command
+
+  return command.replace(/^\s*ssh(?:\.exe)?(?=\s|$)/i, match => {
+    const leadingWhitespace = match.match(/^\s*/)?.[0] || ''
+    return `${leadingWhitespace}${WINDOWS_32_BIT_OPENSSH}`
+  })
+}
+
+export function buildWindowsTerminalCommand(command: string, isWindows32 = environment.isWindows32) {
+  const terminalCommand = command.replace(/^start cmd \/k\s*/i, '')
+  return `start cmd /k ${resolveWindowsTerminalCommand(terminalCommand, isWindows32)}`
+}
+
 export default async function launch(command: string, type: 'TERMINAL' | 'SCRIPT' | 'COMMAND' = 'COMMAND') {
   Logger.info('LAUNCH', { type, path: __filename })
   let scriptPath = ''
@@ -17,7 +33,7 @@ export default async function launch(command: string, type: 'TERMINAL' | 'SCRIPT
     } else if (environment.isLinux) {
       command = `gnome-terminal -- /bin/bash -c '${command}; read'`
     } else {
-      command = `start cmd /k ${command.replace('start cmd /k', '')}`
+      command = buildWindowsTerminalCommand(command)
     }
   }
 


### PR DESCRIPTION
## Summary
- Route 32-bit Windows Desktop terminal SSH launches through `%WINDIR%\Sysnative\OpenSSH\ssh.exe` when the backend is about to execute a plain `ssh` or `ssh.exe` command.
- Leave shared/web launch templates unchanged; web mode can render/copy launch strings, but has no backend socket to execute terminal launches.
- Add regression coverage for backend launch rewriting.

## Root Cause
The Desktop app can run as a 32-bit Windows process. When that process starts `cmd` and asks for `ssh`, Windows file system redirection can hide the native OpenSSH location under `System32`, causing the launch to fail even though `ssh.exe` works from a normal command prompt.

## Mode Behavior
- Desktop with backend: `LaunchButton` emits `launch/app`, the Electron backend receives it, and terminal launch execution rewrites only a leading `ssh`/`ssh.exe` to `%WINDIR%\Sysnative\OpenSSH\ssh.exe` when the Desktop process is 32-bit Windows.
- Web/portal without backend: no local socket is opened, non-URL launch methods are not executable, and this backend-only rewrite is not involved.

## Validation
- `npm run build-common`
- `npm test -w=electron -- --runTestsByPath src/backend/launch.test.ts`
- `npm run typecheck -w=electron`
- `npm run typecheck -w=frontend`
- `npm test -w=electron -- --runInBand`
- `git diff --check`
