### PR TITLE
fix(tags): alpha-sort tag lists across UI

### DIFF
--- a/frontend/src/components/Tags.tsx
+++ b/frontend/src/components/Tags.tsx
@@ -16,7 +16,7 @@ export const Tags: React.FC<TagProps> = ({ tags, small, max = 1, showEmpty, hide
   const dot = tags.length > max && small
 
   const Tags = [...tags]
-    .sort(colorSort)
+    .sort(nameSort)
     .map((tag, index) => (
       <Tag
         key={index}
@@ -38,7 +38,6 @@ export const Tags: React.FC<TagProps> = ({ tags, small, max = 1, showEmpty, hide
   return <>{dot ? <Chip size="small" label={Tags} /> : Tags}</>
 }
 
-function colorSort(a: ITag, b: ITag) {
-  return a.color < b.color ? -1 : 1
-  // return a.name.localeCompare(b.name)
+function nameSort(a: ITag, b: ITag) {
+  return a.name.localeCompare(b.name)
 }

--- a/frontend/src/helpers/selectedHelper.ts
+++ b/frontend/src/helpers/selectedHelper.ts
@@ -17,6 +17,5 @@ export function getSelectedTags(devices?: IDevice[], selected?: IDevice['id'][])
       })
     }
   })
-  // sort
-  return result
+  return result.sort((a, b) => a.name.localeCompare(b.name))
 }

--- a/frontend/src/selectors/tags.ts
+++ b/frontend/src/selectors/tags.ts
@@ -2,4 +2,6 @@ import { getTags } from './state'
 import { createSelector } from 'reselect'
 import { selectActiveAccountId } from './accounts'
 
-export const selectTags = createSelector([getTags, selectActiveAccountId], (tags, accountId) => tags[accountId] || [])
+export const selectTags = createSelector([getTags, selectActiveAccountId], (tags, accountId) =>
+  [...(tags[accountId] || [])].sort((a, b) => a.name.localeCompare(b.name))
+)


### PR DESCRIPTION
## Summary
- Sort tags by name in the `selectTags` selector so all consumers get a memoized, alpha-sorted list
- Switch the shared `Tags` chip component from color-sort to name-sort (covers tag editors, filters, reactive lists, etc.)
- Sort the deduped result in `getSelectedTags` (used by the devices action bar)

## Test plan
- [ ] Tags page lists tags A→Z
- [ ] Devices filter drawer tag list is A→Z
- [ ] Device/Network tag editor chips display A→Z
- [ ] Tag autocomplete dropdown options are A→Z
- [ ] Role/access tag filter chips A→Z