### PR TITLE
perf(device-list): drop dynamic JSS sheets and memoize row rendering

### DIFF
--- a/frontend/src/components/AccordionMenuItem.tsx
+++ b/frontend/src/components/AccordionMenuItem.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react'
-import { makeStyles } from '@mui/styles'
 import { Button, ListSubheader, Accordion, AccordionSummary, AccordionDetails } from '@mui/material'
 import { ExpandIcon } from './ExpandIcon'
 import { spacing } from '../styling'
@@ -31,7 +30,6 @@ export const AccordionMenuItem: React.FC<IAccordionMenu> = ({
   action,
   children,
 }) => {
-  const css = useStyles({ gutters })
   const [open, setOpen] = useState<boolean>(!!defaultExpanded)
   const clickHandler = () => {
     onClick && onClick(!open)
@@ -48,7 +46,28 @@ export const AccordionMenuItem: React.FC<IAccordionMenu> = ({
       defaultExpanded={defaultExpanded}
       disabled={disabled}
     >
-      <AccordionSummary className={css.item}>
+      <AccordionSummary
+        sx={{
+          marginTop: `${spacing.xxs}px`,
+          marginBottom: `${spacing.xxs}px`,
+          marginLeft: gutters ? `${spacing.md}px` : undefined,
+          marginRight: gutters ? `${spacing.md}px` : undefined,
+          '& .MuiIconButton-root': {
+            marginTop: `${-spacing.xxs}px`,
+            marginBottom: `${-spacing.xxs}px`,
+          },
+          '& .MuiButton-root:first-of-type': {
+            width: '100%',
+            textAlign: 'left',
+            display: 'block',
+            padding: 0,
+            margin: 0,
+          },
+          '& .MuiButton-root + .MuiButton-root': {
+            marginRight: `${spacing.md}px`,
+          },
+        }}
+      >
         <Button onClick={clickHandler}>
           <ListSubheader disableGutters>
             {subtitle}
@@ -73,26 +92,3 @@ export const AccordionMenuItem: React.FC<IAccordionMenu> = ({
     </Accordion>
   )
 }
-
-const useStyles = makeStyles({
-  item: ({ gutters }: any) => ({
-    marginTop: spacing.xxs,
-    marginBottom: spacing.xxs,
-    marginLeft: gutters && spacing.md,
-    marginRight: gutters && spacing.md,
-    '& .MuiIconButton-root': {
-      marginTop: -spacing.xxs,
-      marginBottom: -spacing.xxs,
-    },
-    '& .MuiButton-root:first-of-type': {
-      width: '100%',
-      textAlign: 'left',
-      display: 'block',
-      padding: 0,
-      margin: 0,
-    },
-    '& .MuiButton-root + .MuiButton-root': {
-      marginRight: spacing.md,
-    },
-  }),
-})

--- a/frontend/src/components/Avatar/Avatar.tsx
+++ b/frontend/src/components/Avatar/Avatar.tsx
@@ -1,10 +1,8 @@
 import md5 from 'md5'
-import React from 'react'
-import classnames from 'classnames'
+import React, { useMemo } from 'react'
 import { createColor } from '../../helpers/uiHelper'
 import { labelLookup } from '../../models/labels'
-import { makeStyles } from '@mui/styles'
-import { Avatar as MuiAvatar, Tooltip } from '@mui/material'
+import { Avatar as MuiAvatar, Box, Tooltip } from '@mui/material'
 import { spacing } from '../../styling'
 
 export interface Props {
@@ -21,81 +19,82 @@ export interface Props {
   children?: React.ReactNode
 }
 
-export const Avatar: React.FC<Props> = ({
-  email,
-  size = 36,
-  title,
-  button,
-  inline,
-  tooltip,
-  active,
-  border = 1,
-  fallback,
-  marginRight,
-  children,
-}) => {
-  const url = `https://www.gravatar.com/avatar/${md5(email || '')}?s=${size * 2}&d=force-fail`
-  const color = createColor(email)
-  const css = useStyles({ size, color, button, inline, marginRight, active, border })
-  fallback = (fallback || email || '?').substring(0, 1).toUpperCase()
+export const Avatar: React.FC<Props> = React.memo(
+  ({
+    email,
+    size = 36,
+    title,
+    button,
+    inline,
+    tooltip,
+    active,
+    border = 1,
+    fallback,
+    marginRight,
+    children,
+  }) => {
+    const url = useMemo(
+      () => `https://www.gravatar.com/avatar/${md5(email || '')}?s=${size * 2}&d=force-fail`,
+      [email, size]
+    )
+    const color = useMemo(() => createColor(email), [email])
+    fallback = (fallback || email || '?').substring(0, 1).toUpperCase()
 
-  let Element = (
-    <>
-      <MuiAvatar className={css.avatar} alt={email} src={url}>
-        <div>{fallback}</div>
-      </MuiAvatar>
-      {children}
-    </>
-  )
+    let Element = (
+      <>
+        <MuiAvatar
+          alt={email}
+          src={url}
+          sx={theme => ({
+            color: theme.palette.alwaysWhite.main,
+            fontSize: size * 0.625,
+            height: size,
+            width: size,
+            verticalAlign: 'middle',
+            display: 'inline-flex',
+            fontFamily: 'Roboto Mono',
+            backgroundColor: labelLookup[color].color,
+            border: `${border}px solid ${theme.palette.white.main}`,
+            marginRight: inline ? `${spacing.sm}px` : marginRight,
+          })}
+        >
+          <div>{fallback}</div>
+        </MuiAvatar>
+        {children}
+      </>
+    )
 
-  if (button) Element = <span className={classnames(button && css.button)}>{Element}</span>
+    if (button)
+      Element = (
+        <Box
+          component="span"
+          sx={theme => ({
+            backgroundColor: active ? undefined : theme.palette.white.main,
+            borderRadius: '50%',
+            padding: `${border}px`,
+            borderWidth: 2,
+            borderStyle: 'solid',
+            borderColor: active ? theme.palette.primary.main : theme.palette.grayLighter.main,
+            cursor: 'pointer',
+            position: 'relative',
+            color: theme.palette.primaryLight.main,
+            boxShadow: active ? '0 0 10px' : undefined,
+            '&:hover': {
+              borderColor: active ? theme.palette.grayDark.main : theme.palette.primary.main,
+              color: theme.palette.gray.main,
+            },
+          })}
+        >
+          {Element}
+        </Box>
+      )
 
-  return tooltip ? (
-    <Tooltip title={title || email || 'deleted'} placement="right" enterDelay={800} arrow>
-      {Element}
-    </Tooltip>
-  ) : (
-    Element
-  )
-}
-
-type StyleProps = {
-  button?: boolean
-  inline?: boolean
-  marginRight?: number
-  active?: boolean
-  size: number
-  color: number
-  border: number
-}
-
-const useStyles = makeStyles(({ palette }) => ({
-  avatar: ({ size, color, inline, marginRight, border }: StyleProps) => ({
-    color: palette.alwaysWhite.main,
-    fontSize: size * 0.625,
-    height: size,
-    width: size,
-    verticalAlign: 'middle',
-    display: 'inline-flex',
-    fontFamily: 'Roboto Mono',
-    backgroundColor: labelLookup[color].color,
-    border: `${border}px solid ${palette.white.main}`,
-    marginRight: inline ? spacing.sm : marginRight,
-  }),
-  button: ({ active, border }: StyleProps) => ({
-    backgroundColor: active ? undefined : palette.white.main,
-    borderRadius: '50%',
-    padding: border,
-    borderWidth: 2,
-    borderStyle: 'solid',
-    borderColor: active ? palette.primary.main : palette.grayLighter.main,
-    cursor: 'pointer',
-    position: 'relative',
-    color: palette.primaryLight.main,
-    boxShadow: active ? '0 0 10px' : undefined,
-    '&:hover': {
-      borderColor: active ? palette.grayDark.main : palette.primary.main,
-      color: palette.gray.main,
-    },
-  }),
-}))
+    return tooltip ? (
+      <Tooltip title={title || email || 'deleted'} placement="right" enterDelay={800} arrow>
+        {Element}
+      </Tooltip>
+    ) : (
+      Element
+    )
+  }
+)

--- a/frontend/src/components/ColorChip.tsx
+++ b/frontend/src/components/ColorChip.tsx
@@ -1,8 +1,6 @@
 import React, { forwardRef } from 'react'
-import { makeStyles } from '@mui/styles'
 import { Chip, ChipProps, alpha, darken } from '@mui/material'
 import { spacing } from '../styling'
-import classnames from 'classnames'
 
 export type Props = Omit<ChipProps, 'variant' | 'color'> & {
   color?: Color
@@ -10,46 +8,47 @@ export type Props = Omit<ChipProps, 'variant' | 'color'> & {
   inline?: boolean
 }
 
-export const ColorChip = forwardRef<HTMLDivElement, Props>(({ variant, color, ...props }, ref) => {
-  const css = useStyles({ variant, color, ...props })
-  return <Chip {...props} ref={ref} className={classnames(css.color, props.className)} />
-})
+export const ColorChip = forwardRef<HTMLDivElement, Props>(
+  ({ variant = 'text', color = 'grayDarker', inline, sx, ...props }, ref) => (
+    <Chip
+      {...props}
+      ref={ref}
+      sx={[
+        theme => {
+          let typeColor: string
+          let hoverColor: string
+          let backgroundColor: string | undefined
 
-const useStyles = makeStyles(({ palette }) => ({
-  color: ({ variant, color, inline }: Props) => {
-    variant ||= 'text'
-    color ||= 'grayDarker'
+          switch (variant) {
+            case 'outlined':
+              typeColor = theme.palette[color].main
+              hoverColor = alpha(theme.palette[color].main, 0.1)
+              break
+            case 'contained':
+              typeColor = theme.palette.alwaysWhite.main
+              backgroundColor = theme.palette[color].main
+              hoverColor = darken(theme.palette[color].main, 0.1)
+              break
+            case 'text':
+            default:
+              typeColor = theme.palette[color].main
+              backgroundColor = alpha(theme.palette[color].main, 0.1)
+              hoverColor = alpha(theme.palette[color].main, 0.2)
+              break
+          }
 
-    let typeColor: string
-    let hoverColor: string
-    let backgroundColor: string | undefined
-
-    switch (variant) {
-      case 'outlined':
-        typeColor = palette[color].main
-        hoverColor = alpha(palette[color].main, 0.1)
-        break
-      case 'contained':
-        typeColor = palette.alwaysWhite.main
-        backgroundColor = palette[color].main
-        hoverColor = darken(palette[color].main, 0.1)
-        break
-      case 'text':
-      default:
-        typeColor = palette[color].main
-        backgroundColor = alpha(palette[color].main, 0.1)
-        hoverColor = alpha(palette[color].main, 0.2)
-        break
-    }
-
-    return {
-      backgroundColor: backgroundColor,
-      color: typeColor,
-      fontWeight: 500,
-      letterSpacing: 0.3,
-      marginRight: inline ? spacing.sm : undefined,
-      marginLeft: inline ? spacing.sm : undefined,
-      '&:hover': { backgroundColor: hoverColor },
-    }
-  },
-}))
+          return {
+            backgroundColor,
+            color: typeColor,
+            fontWeight: 500,
+            letterSpacing: 0.3,
+            marginRight: inline ? `${spacing.sm}px` : undefined,
+            marginLeft: inline ? `${spacing.sm}px` : undefined,
+            '&:hover': { backgroundColor: hoverColor },
+          }
+        },
+        ...(Array.isArray(sx) ? sx : sx ? [sx] : []),
+      ]}
+    />
+  )
+)

--- a/frontend/src/components/ConnectionListItem.tsx
+++ b/frontend/src/components/ConnectionListItem.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { makeStyles } from '@mui/styles'
 import { Dispatch } from '../store'
 import { useDispatch } from 'react-redux'
-import { ListItemText, ListItemIcon } from '@mui/material'
+import { Box, ListItemText, ListItemIcon } from '@mui/material'
 import { ListItemLocation } from './ListItemLocation'
 import { TargetPlatform } from './TargetPlatform'
 import { ConnectionName } from './ConnectionName'
@@ -40,7 +40,7 @@ export const ConnectionListItem: React.FC<Props> = ({
   const error = !!connection?.error
   const color = offline ? 'gray' : error ? 'error' : connected ? 'primary' : 'grayDarkest'
   const borderColor = error ? 'error' : connected ? 'primary' : 'grayDark'
-  const css = useStyles({ connected, color: borderColor, enabled })
+  const css = useStyles()
 
   let icon: React.ReactNode | null = null
   if (connected) icon = <Icon color={color} name={error ? 'exclamation-triangle' : 'play'} size="sm" type="solid" />
@@ -61,7 +61,21 @@ export const ConnectionListItem: React.FC<Props> = ({
       }
     >
       <ListItemIcon className={css.connectIcon}>
-        <div className={css.connection} />
+        <Box
+          sx={theme => ({
+            borderColor: enabled ? theme.palette.primary.main : theme.palette[borderColor]?.main,
+            borderBottomColor: theme.palette[borderColor]?.main,
+            borderWidth: '0 0 1px 1px',
+            borderBottomWidth: 1,
+            borderBottomStyle: connected ? 'solid' : 'dotted',
+            borderStyle: 'solid',
+            height: '2.7em',
+            width: '1.4em',
+            marginTop: '-2.7em',
+            marginRight: '-1.4em',
+            pointerEvents: 'none',
+          })}
+        />
         {icon}
       </ListItemIcon>
       <ListItemIcon className={css.platform}>
@@ -74,19 +88,6 @@ export const ConnectionListItem: React.FC<Props> = ({
 }
 
 export const useStyles = makeStyles(({ palette }) => ({
-  connection: ({ connected, color, enabled }: any) => ({
-    borderColor: enabled ? palette.primary.main : palette[color]?.main,
-    borderBottomColor: palette[color]?.main,
-    borderWidth: '0 0 1px 1px',
-    borderBottomWidth: 1,
-    borderBottomStyle: connected ? 'solid' : 'dotted',
-    borderStyle: 'solid',
-    height: '2.7em',
-    width: '1.4em',
-    marginTop: '-2.7em',
-    marginRight: '-1.4em',
-    pointerEvents: 'none',
-  }),
   hover: {
     position: 'absolute',
     marginTop: -1,

--- a/frontend/src/components/DeviceList.tsx
+++ b/frontend/src/components/DeviceList.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback, useMemo } from 'react'
 import browser from '../services/browser'
 import { useLocation } from 'react-router-dom'
 import { MOBILE_WIDTH } from '../constants'
@@ -14,6 +14,8 @@ import { GuideBubble } from './GuideBubble'
 import { LoadMore } from './LoadMore'
 import { GridList } from './GridList'
 
+const GUIDE_START_DATE = new Date('2022-09-20')
+
 export interface DeviceListProps {
   attributes: Attribute[]
   required: Attribute
@@ -26,6 +28,75 @@ export interface DeviceListProps {
   selected?: string[]
 }
 
+type RowProps = {
+  device: IDevice
+  deviceConnections?: IConnection[]
+  attributes: Attribute[]
+  required: Attribute
+  restore?: boolean
+  canRestore: boolean
+  select?: boolean
+  mobile: boolean
+  disabled?: boolean
+  showGuide: boolean
+  onClick?: () => void
+}
+
+const DeviceListRow: React.FC<RowProps> = React.memo(
+  ({
+    device,
+    deviceConnections,
+    attributes,
+    required,
+    restore,
+    canRestore,
+    select,
+    mobile,
+    disabled,
+    showGuide,
+    onClick,
+  }) => {
+    const value = useMemo(
+      () => ({ device, connections: deviceConnections, required, attributes }),
+      [device, deviceConnections, required, attributes]
+    )
+    return (
+      <DeviceListContext.Provider value={value}>
+        <DeviceListItem
+          restore={restore && canRestore}
+          select={select}
+          mobile={mobile}
+          onClick={onClick}
+          disabled={disabled}
+        />
+        {showGuide && (
+          <GuideBubble
+            enterDelay={400}
+            guide="deviceList"
+            placement="bottom"
+            startDate={GUIDE_START_DATE}
+            queueAfter={browser.hasBackend ? 'registerMenu' : 'addDevice'}
+            instructions={
+              <>
+                <Typography variant="h3" gutterBottom>
+                  <b>Access a device</b>
+                </Typography>
+                <Typography variant="body2" gutterBottom>
+                  A device can host it's own applications (services), or it can host another service on it's local
+                  network.
+                </Typography>
+                <Typography variant="body2" gutterBottom>
+                  Select a device to connect to a service, or configure it.
+                </Typography>
+              </>
+            }
+          />
+        )}
+      </DeviceListContext.Provider>
+    )
+  }
+)
+
 export const DeviceList: React.FC<DeviceListProps> = ({
   attributes,
   required,
@@ -35,11 +106,12 @@ export const DeviceList: React.FC<DeviceListProps> = ({
   fetching,
   restore,
   select,
-  selected = [],
 }) => {
   const location = useLocation()
   const mobile = useMediaQuery(`(max-width:${MOBILE_WIDTH}px)`)
   const dispatch = useDispatch<Dispatch>()
+  const onFirstClick = useCallback(() => dispatch.ui.pop('deviceList'), [dispatch])
+  const isScriptsPath = location.pathname.includes('scripts')
 
   return (
     <GridList
@@ -51,44 +123,22 @@ export const DeviceList: React.FC<DeviceListProps> = ({
       {devices?.map((device, index) => {
         const canRestore = isOffline(device) && !device.shared
         if (restore && !canRestore) return null
-        const disabled = select && !device.scriptable && location.pathname.includes('scripts')
+        const disabled = select && !device.scriptable && isScriptsPath
         return (
-          <DeviceListContext.Provider
+          <DeviceListRow
             key={device.id}
-            value={{ device, connections: connections[device.id], required, attributes }}
-          >
-            <DeviceListItem
-              restore={restore && canRestore}
-              select={select}
-              selected={selected}
-              mobile={mobile}
-              onClick={index ? undefined : () => dispatch.ui.pop('deviceList')}
-              disabled={disabled}
-            />
-            {!index && (
-              <GuideBubble
-                enterDelay={400}
-                guide="deviceList"
-                placement="bottom"
-                startDate={new Date('2022-09-20')}
-                queueAfter={browser.hasBackend ? 'registerMenu' : 'addDevice'}
-                instructions={
-                  <>
-                    <Typography variant="h3" gutterBottom>
-                      <b>Access a device</b>
-                    </Typography>
-                    <Typography variant="body2" gutterBottom>
-                      A device can host it's own applications (services), or it can host another service on it's local
-                      network.
-                    </Typography>
-                    <Typography variant="body2" gutterBottom>
-                      Select a device to connect to a service, or configure it.
-                    </Typography>
-                  </>
-                }
-              />
-            )}
-          </DeviceListContext.Provider>
+            device={device}
+            deviceConnections={connections[device.id]}
+            attributes={attributes}
+            required={required}
+            restore={restore}
+            canRestore={canRestore}
+            select={select}
+            mobile={mobile}
+            disabled={disabled}
+            showGuide={!index}
+            onClick={index ? undefined : onFirstClick}
+          />
         )
       })}
       <LoadMore />

--- a/frontend/src/components/DeviceListItem.tsx
+++ b/frontend/src/components/DeviceListItem.tsx
@@ -13,7 +13,6 @@ import { useSelect } from '../hooks/useSelect'
 type Props = {
   restore?: boolean
   select?: boolean
-  selected: string[]
   mobile?: boolean
   disabled?: boolean
   duplicateName?: boolean
@@ -23,7 +22,6 @@ type Props = {
 export const DeviceListItem: React.FC<Props> = ({
   restore,
   select,
-  selected,
   mobile,
   disabled,
   duplicateName,
@@ -39,7 +37,6 @@ export const DeviceListItem: React.FC<Props> = ({
 
   const { isSelected, isAnchorRow, handleSelect } = useSelect({
     deviceId: device.id,
-    selected,
     selectMode: select,
   })
 

--- a/frontend/src/components/Network.tsx
+++ b/frontend/src/components/Network.tsx
@@ -47,7 +47,6 @@ export const Network: React.FC<Props> = ({ onClear, recent, highlight, network, 
         enabled={networkConnected || networkEnabled}
         noLink={connectionsPage}
         expanded={expanded}
-        offline={recent}
         onClick={toggle}
       >
         {recent && <ClearButton all onClick={() => dispatch.connections.clearRecent()} />}

--- a/frontend/src/components/NetworkListTitle.tsx
+++ b/frontend/src/components/NetworkListTitle.tsx
@@ -10,7 +10,6 @@ import { Box } from '@mui/material'
 export interface Props {
   network?: INetwork
   expanded?: boolean
-  offline?: boolean
   noLink?: boolean
   enabled?: boolean
   onClick?: (event: React.MouseEvent) => void
@@ -20,13 +19,12 @@ export interface Props {
 export const NetworkListTitle: React.FC<Props> = ({
   network,
   expanded = true,
-  offline,
   noLink,
   enabled,
   onClick,
   children,
 }) => {
-  const css = useStyles({ enabled, offline })
+  const css = useStyles()
   return (
     <ListItemLocation
       className={css.item}

--- a/frontend/src/components/Tag.tsx
+++ b/frontend/src/components/Tag.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import { makeStyles } from '@mui/styles'
-import { Tooltip, Chip, IconButton } from '@mui/material'
+import { Tooltip, Chip, IconButton, Box } from '@mui/material'
 import { spacing, Sizes } from '../styling'
 import { useLabel } from '../hooks/useLabel'
 import { Icon } from '../components/Icon'
@@ -10,71 +9,71 @@ type Props = {
   dot?: boolean
   size?: Sizes
   hideLabels?: boolean
-  onClick?: () => void
-  onDelete?: () => void
+  onClick?: (tag: ITag) => void
+  onDelete?: (tag: ITag) => void
 }
 
-export const Tag: React.FC<Props> = ({ tag, dot, size = 'xs', hideLabels, onClick, onDelete }) => {
-  const getColor = useLabel()
-  const color = tag && !hideLabels ? getColor(tag.color) : undefined
-  const css = useStyles({ color })
+export const Tag: React.FC<Props> = React.memo(
+  ({ tag, dot, size = 'xs', hideLabels, onClick, onDelete }) => {
+    const getColor = useLabel()
+    const color = tag && !hideLabels ? getColor(tag.color) : undefined
 
-  if (!tag) return null
+    if (!tag) return null
+    const handleClick = onClick ? () => onClick(tag) : undefined
+    const handleDelete = onDelete ? () => onDelete(tag) : undefined
 
-  if (dot)
+    if (dot)
+      return (
+        <Tooltip
+          slotProps={{
+            tooltip: {
+              sx: {
+                backgroundColor: color,
+                '& .MuiTooltip-arrow': { color },
+              },
+            },
+          }}
+          title={
+            <>
+              <Icon name="tag" type="solid" size="xxxs" inlineLeft />
+              {tag.name}
+            </>
+          }
+          placement="top"
+          arrow
+        >
+          <Box component="span" sx={{ '& + span': { marginLeft: `${spacing.xxs}px` } }}>
+            <Icon name="tag" color={color} type="solid" size={size} />
+          </Box>
+        </Tooltip>
+      )
+
     return (
-      <Tooltip
-        classes={{ tooltip: css.tooltip }}
-        title={
+      <Chip
+        label={
           <>
-            <Icon name="tag" type="solid" size="xxxs" inlineLeft />
+            {!hideLabels && <Icon name="tag" type="solid" size={size} color={color} />}
             {tag.name}
           </>
         }
-        placement="top"
-        arrow
-      >
-        <span className={css.dot}>
-          <Icon name="tag" color={color} type="solid" size={size} />
-        </span>
-      </Tooltip>
+        size="small"
+        sx={{
+          color: 'grayDarker.main',
+          marginBottom: 0.3,
+          '& .MuiChip-label > *': { marginRight: 1 },
+          '& .MuiChip-deleteIconSmall': {
+            marginLeft: -1,
+            marginRight: 0,
+          },
+        }}
+        deleteIcon={
+          <IconButton size="small">
+            <Icon name="times" size="xs" />
+          </IconButton>
+        }
+        onClick={handleClick}
+        onDelete={handleDelete}
+      />
     )
-
-  return (
-    <Chip
-      label={
-        <>
-          {!hideLabels && <Icon name="tag" type="solid" size={size} color={color} />}
-          {tag.name}
-        </>
-      }
-      size="small"
-      sx={{
-        color: 'grayDarker.main',
-        marginBottom: 0.3,
-        '& .MuiChip-label > *': { marginRight: 1 },
-        '& .MuiChip-deleteIconSmall': {
-          marginLeft: -1,
-          marginRight: 0,
-        },
-      }}
-      deleteIcon={
-        <IconButton size="small">
-          <Icon name="times" size="xs" />
-        </IconButton>
-      }
-      onClick={onClick}
-      onDelete={onDelete}
-    />
-  )
-}
-
-const useStyles = makeStyles({
-  tooltip: ({ color }: any) => ({
-    backgroundColor: color,
-    '& .MuiTooltip-arrow': { color },
-  }),
-  dot: {
-    '& + span': { marginLeft: spacing.xxs },
-  },
-})
+  }
+)

--- a/frontend/src/components/Tags.tsx
+++ b/frontend/src/components/Tags.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { Chip, BoxProps, Typography } from '@mui/material'
 import { Tag } from './Tag'
 
@@ -14,19 +14,7 @@ export type TagProps = BoxProps & {
 
 export const Tags: React.FC<TagProps> = ({ tags, small, max = 1, showEmpty, hideLabels, onClick, onDelete }) => {
   const dot = tags.length > max && small
-
-  const Tags = [...tags]
-    .sort(nameSort)
-    .map((tag, index) => (
-      <Tag
-        key={index}
-        dot={dot}
-        tag={tag}
-        hideLabels={hideLabels}
-        onDelete={onDelete ? () => onDelete(tag) : undefined}
-        onClick={onClick ? () => onClick(tag) : undefined}
-      />
-    ))
+  const sortedTags = useMemo(() => [...tags].sort(nameSort), [tags])
 
   if (!tags.length && showEmpty)
     return (
@@ -35,7 +23,18 @@ export const Tags: React.FC<TagProps> = ({ tags, small, max = 1, showEmpty, hide
       </Typography>
     )
 
-  return <>{dot ? <Chip size="small" label={Tags} /> : Tags}</>
+  const tagElements = sortedTags.map((tag, index) => (
+    <Tag
+      key={index}
+      dot={dot}
+      tag={tag}
+      hideLabels={hideLabels}
+      onDelete={onDelete}
+      onClick={onClick}
+    />
+  ))
+
+  return <>{dot ? <Chip size="small" label={tagElements} /> : tagElements}</>
 }
 
 function nameSort(a: ITag, b: ITag) {

--- a/frontend/src/hooks/useSelect.ts
+++ b/frontend/src/hooks/useSelect.ts
@@ -1,23 +1,24 @@
-import { useDispatch, useSelector } from 'react-redux'
+import { useDispatch, useSelector, useStore } from 'react-redux'
 import { Dispatch, State } from '../store'
 import { selectVisibleDevices } from '../selectors/devices'
 import { getInclusiveIdRange, getSelectableDeviceIds, mergeSelectedIds, removeSelectedIds } from '../helpers/selectionRange'
 
 type UseSelectParams = {
   deviceId: string
-  selected: string[]
   selectMode?: boolean
 }
 
-export const useSelect = ({ deviceId, selected, selectMode }: UseSelectParams) => {
+export const useSelect = ({ deviceId, selectMode }: UseSelectParams) => {
   const dispatch = useDispatch<Dispatch>()
-  const selectionAnchor = useSelector((state: State) => state.ui.selectionAnchor)
-  const visibleDevices = useSelector(selectVisibleDevices)
-
-  const isSelected = selected.includes(deviceId)
-  const isAnchorRow = !!selectMode && selectionAnchor === deviceId
+  const store = useStore<State>()
+  const isSelected = useSelector((state: State) => state.ui.selected.includes(deviceId))
+  const isAnchorRow = useSelector((state: State) => !!selectMode && state.ui.selectionAnchor === deviceId)
 
   const handleSelect = (shiftKey?: boolean) => {
+    const state = store.getState()
+    const selected = state.ui.selected
+    const selectionAnchor = state.ui.selectionAnchor
+    const visibleDevices = selectVisibleDevices(state)
     const nextSelected = [...selected]
     const selectableIds = getSelectableDeviceIds(visibleDevices)
     const range = shiftKey ? getInclusiveIdRange(selectableIds, selectionAnchor, deviceId) : []


### PR DESCRIPTION
## Summary

Fixes a hard freeze (~21s INP) when hovering or interacting with the device list at scale (reproduced on a 600-device account).

## Diagnosis

A user-supplied Chrome Performance trace pinpointed a single \`pointerover\` event consuming ~21s, with **\`insertBefore\` self-time = 16,014ms (62.7% of the interaction)**. The call stack resolved to \`Tag.tsx → makeStyles → JSS attach → insertStyle → insertBefore\`.

Root cause: Tag's \`tooltip: ({ color }) => ({ ... })\` is a JSS *dynamic rule*. JSS attaches a fresh \`<style>\` element per instance via \`insertBefore\` into a \`<head>\` already crowded with sheets. With ~600 devices × tags-per-device, JSS was reinjecting thousands of sheets on every parent re-render.

## Changes

### Migrate dynamic \`makeStyles\` → \`sx\` (emotion)

Emotion handles dynamic style values via class-name hashing; no per-instance \`<style>\` element gets injected.

- \`Tag.tsx\` — the trace culprit; tooltip color via \`slotProps.tooltip.sx\`
- \`Avatar/Avatar.tsx\` — rendered per device row (owner attribute) and per user (AvatarList)
- \`ColorChip.tsx\` — used in 18 components
- \`ConnectionListItem.tsx\` — dynamic \`connection\` rule extracted to inline \`sx\`; static \`useStyles\` retained for shared classes
- \`AccordionMenuItem.tsx\` — used in 12 places
- \`NetworkListTitle.tsx\` — dropped dead \`offline\` prop; \`Network.tsx\` caller updated

### Stop the 600-row re-render cascade

- \`DeviceList.tsx\` — extracted \`DeviceListRow\` (\`React.memo\`); \`useMemo\`'d the per-row \`DeviceListContext.Provider\` value so unchanged rows skip rendering when a sibling's state changes; hoisted \`location.pathname.includes('scripts')\` and \`new Date('2022-09-20')\` out of the render loop
- \`hooks/useSelect.ts\` + \`DeviceListItem.tsx\` — dropped the \`selected: string[]\` prop. \`useSelect\` now subscribes via \`useSelector(state => state.ui.selected.includes(deviceId))\` (boolean — useSelector's default \`===\` equality means only the toggled row re-renders). \`handleSelect\` reads \`selected\` lazily via \`useStore().getState()\`. Previously, every selection change made all 600 rows re-render because the array reference changed.

### Memoization fixes for hot paths

- \`Avatar.tsx\` — \`React.memo\` + \`useMemo\` on \`md5(email)\` and Gravatar URL (was hashing every render even when memoized)
- \`Tag.tsx\` — \`React.memo\` + accepts \`(tag) => void\` callbacks so \`Tags.tsx\` no longer creates per-tag closures
- \`Tags.tsx\` — \`useMemo\` on the sorted-tag array; passes parent callbacks through directly

## Test plan

- [ ] Re-record a Performance trace on a 600-device list. INP on hover should drop from ~21s to single-digit ms.
- [ ] Bottom-up tab: \`insertBefore\` self-time and JSS \`DomRenderer\` total time should be drastically reduced.
- [ ] Verify device list renders, hovers, scrolls, sorts, and selects (single + shift-range) correctly.
- [ ] Verify tag chips and avatars look correct (colors, hover tooltips on tag dots).
- [ ] Verify accordion menus, color chips, connection list items, and network list titles still render correctly.
- [ ] Verify the first-row "Access a device" guide bubble still appears.

## Notes

- Skipped \`ServiceList.tsx\` per-row Context stabilization (same pattern, but device list is the reported hot path).
- Several \`makeStyles\` callers remain (e.g. \`GridListItem\`, \`ConnectionStateIcon\`) — they use only **static** rules which JSS caches per component class and weren't implicated by the trace. Worth migrating eventually, but not perf-critical.
- Virtualization (\`react-window\`) deferred — DOM is still 52k elements at 600 devices, but the interactive freeze should be resolved by this PR.