### PR TITLE
feat(runs): paginate /runs page and link from script page

### DIFF
--- a/frontend/src/buttons/RefreshButton/RefreshButton.tsx
+++ b/frontend/src/buttons/RefreshButton/RefreshButton.tsx
@@ -38,6 +38,7 @@ export const RefreshButton: React.FC<ButtonProps> = props => {
   const adminUsersPage = useRouteMatch('/admin/users')
   const adminPartnersPage = useRouteMatch('/admin/partners')
   const scriptingPage = useRouteMatch(['/script', '/scripts', '/runs'])
+  const runsPage = useRouteMatch<{ fileID?: string }>('/runs/:fileID?')
   const scriptPage = useRouteMatch('/script')
 
   let title = 'Refresh application'
@@ -57,7 +58,8 @@ export const RefreshButton: React.FC<ButtonProps> = props => {
   } else if (scriptingPage) {
     title = 'Refresh scripts'
     methods.push(dispatch.files.fetch)
-    methods.push(dispatch.jobs.fetch)
+    const runsFileID = runsPage?.params.fileID
+    methods.push(async () => await dispatch.jobs.fetch({ fileID: runsFileID }))
 
     // script pages
   } else if (scriptPage) {

--- a/frontend/src/components/DeviceList.tsx
+++ b/frontend/src/components/DeviceList.tsx
@@ -11,7 +11,7 @@ import { DeviceListItem } from './DeviceListItem'
 import { Attribute } from './Attributes'
 import { isOffline } from '../models/devices'
 import { GuideBubble } from './GuideBubble'
-import { LoadMore } from './LoadMore'
+import { DeviceLoadMore } from './LoadMore'
 import { GridList } from './GridList'
 
 const GUIDE_START_DATE = new Date('2022-09-20')
@@ -141,7 +141,7 @@ export const DeviceList: React.FC<DeviceListProps> = ({
           />
         )
       })}
-      <LoadMore />
+      <DeviceLoadMore />
     </GridList>
   )
 }

--- a/frontend/src/components/JobAttributes.tsx
+++ b/frontend/src/components/JobAttributes.tsx
@@ -183,6 +183,7 @@ export const jobAttributes: JobAttribute[] = [
     value: ({ job }) => {
       if (!job?.updated) return null
       const date = new Date(job.updated)
+      const recent = Date.now() - date.getTime() < 24 * 60 * 60 * 1000
       return (
         <Stack sx={{ lineHeight: 1.2 }}>
           <Typography variant="caption" color="grayDarkest.main">
@@ -193,9 +194,11 @@ export const jobAttributes: JobAttribute[] = [
               minute: '2-digit',
             })}
           </Typography>
-          <Typography variant="caption" color="gray.main">
-            <Duration startDate={date} humanizeOptions={{ largest: 1 }} ago />
-          </Typography>
+          {recent && (
+            <Typography variant="caption" color="gray.main">
+              <Duration startDate={date} humanizeOptions={{ largest: 1 }} ago />
+            </Typography>
+          )}
         </Stack>
       )
     },

--- a/frontend/src/components/JobAttributes.tsx
+++ b/frontend/src/components/JobAttributes.tsx
@@ -5,6 +5,7 @@ import { ReactiveTagNames } from './ReactiveTagNames'
 import { JobStatusIcon } from './JobStatusIcon'
 import { Attribute } from './Attributes'
 import { Duration } from './Duration'
+import { DAY_MS } from '../models/logs'
 import { Icon } from './Icon'
 
 const MAX_ROWS = 2
@@ -183,7 +184,7 @@ export const jobAttributes: JobAttribute[] = [
     value: ({ job }) => {
       if (!job?.updated) return null
       const date = new Date(job.updated)
-      const recent = Date.now() - date.getTime() < 24 * 60 * 60 * 1000
+      const recent = Date.now() - date.getTime() < DAY_MS
       return (
         <Stack sx={{ lineHeight: 1.2 }}>
           <Typography variant="caption" color="grayDarkest.main">

--- a/frontend/src/components/JobAttributes.tsx
+++ b/frontend/src/components/JobAttributes.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState, useEffect, useCallback } from 'react'
 import { toLookup } from '../helpers/utilHelper'
-import { Box, Chip, Typography } from '@mui/material'
+import { Box, Chip, Stack, Typography } from '@mui/material'
 import { ReactiveTagNames } from './ReactiveTagNames'
 import { JobStatusIcon } from './JobStatusIcon'
 import { Attribute } from './Attributes'
@@ -179,13 +179,26 @@ export const jobAttributes: JobAttribute[] = [
   new JobAttribute({
     id: 'jobUpdated',
     label: 'Time',
-    defaultWidth: 160,
-    value: ({ job }) =>
-      job?.updated && (
-        <Typography variant="caption" color="grayDarkest.main">
-          <Duration startDate={new Date(job.updated)} humanizeOptions={{ largest: 1 }} ago />
-        </Typography>
-      ),
+    defaultWidth: 180,
+    value: ({ job }) => {
+      if (!job?.updated) return null
+      const date = new Date(job.updated)
+      return (
+        <Stack sx={{ lineHeight: 1.2 }}>
+          <Typography variant="caption" color="grayDarkest.main">
+            {date.toLocaleString(navigator.language, {
+              month: 'short',
+              day: 'numeric',
+              hour: 'numeric',
+              minute: '2-digit',
+            })}
+          </Typography>
+          <Typography variant="caption" color="gray.main">
+            <Duration startDate={date} humanizeOptions={{ largest: 1 }} ago />
+          </Typography>
+        </Stack>
+      )
+    },
   }),
   new JobAttribute({
     id: 'jobTags',

--- a/frontend/src/components/JobList.tsx
+++ b/frontend/src/components/JobList.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { MOBILE_WIDTH } from '../constants'
 import { useMediaQuery } from '@mui/material'
 import { JobListItem } from './JobListItem'
+import { JobLoadMore } from './JobLoadMore'
 import { Attribute } from './Attributes'
 import { GridList } from './GridList'
 
@@ -13,15 +14,26 @@ export interface ScriptListProps {
   jobs?: IJob[]
   hideIcon?: boolean
   activeJobId?: string
+  loadMore?: boolean
 }
 
-export const JobList: React.FC<ScriptListProps> = ({ attributes, required, jobs = [], columnWidths, fetching, hideIcon, activeJobId }) => {
+export const JobList: React.FC<ScriptListProps> = ({
+  attributes,
+  required,
+  jobs = [],
+  columnWidths,
+  fetching,
+  hideIcon,
+  activeJobId,
+  loadMore,
+}) => {
   const mobile = useMediaQuery(`(max-width:${MOBILE_WIDTH}px)`)
   return (
     <GridList {...{ attributes, required, fetching, columnWidths, mobile }} headerIcon>
       {jobs?.map((job, index) => (
         <JobListItem key={index} {...{ job, required, attributes, mobile, hideIcon, activeJobId }} />
       ))}
+      {loadMore && <JobLoadMore />}
     </GridList>
   )
 }

--- a/frontend/src/components/JobList.tsx
+++ b/frontend/src/components/JobList.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { MOBILE_WIDTH } from '../constants'
 import { useMediaQuery } from '@mui/material'
 import { JobListItem } from './JobListItem'
-import { JobLoadMore } from './JobLoadMore'
+import { JobLoadMore } from './LoadMore'
 import { Attribute } from './Attributes'
 import { GridList } from './GridList'
 

--- a/frontend/src/components/JobLoadMore.tsx
+++ b/frontend/src/components/JobLoadMore.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { useParams } from 'react-router-dom'
+import { useDispatch, useSelector } from 'react-redux'
+import { Dispatch, State } from '../store'
+import { LoadMore } from './LoadMore'
+
+export const JobLoadMore: React.FC = () => {
+  const { fileID } = useParams<{ fileID?: string }>()
+  const from = useSelector((state: State) => state.jobs.from)
+  const size = useSelector((state: State) => state.jobs.size)
+  const total = useSelector((state: State) => state.jobs.total)
+  const fetching = useSelector((state: State) => state.jobs.fetching)
+  const dispatch = useDispatch<Dispatch>()
+
+  return (
+    <LoadMore
+      {...{ from, size, fetching }}
+      count={total}
+      onLoadMore={() => dispatch.jobs.loadMore({ fileID })}
+    />
+  )
+}

--- a/frontend/src/components/LoadMore/DeviceLoadMore.tsx
+++ b/frontend/src/components/LoadMore/DeviceLoadMore.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { Dispatch, State } from '../../store'
+import { selectDeviceModelAttributes } from '../../selectors/devices'
+import { LoadMore } from './LoadMore'
+
+export const DeviceLoadMore: React.FC = () => {
+  const { from, size, total, results, searched, fetching } = useSelector((state: State) =>
+    selectDeviceModelAttributes(state)
+  )
+  const dispatch = useDispatch<Dispatch>()
+  const count = searched ? results : total
+
+  const onLoadMore = () => {
+    const nextFrom = (Math.floor(from / size) + 1) * size
+    dispatch.devices.set({ from: nextFrom, append: true })
+    dispatch.devices.fetchList()
+  }
+
+  return <LoadMore {...{ from, size, count, fetching, onLoadMore }} />
+}

--- a/frontend/src/components/LoadMore/JobLoadMore.tsx
+++ b/frontend/src/components/LoadMore/JobLoadMore.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useParams } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
-import { Dispatch, State } from '../store'
+import { Dispatch, State } from '../../store'
 import { LoadMore } from './LoadMore'
 
 export const JobLoadMore: React.FC = () => {

--- a/frontend/src/components/LoadMore/LoadMore.tsx
+++ b/frontend/src/components/LoadMore/LoadMore.tsx
@@ -1,19 +1,17 @@
 import React from 'react'
-import { Dispatch, State } from '../../store'
-import { selectDeviceModelAttributes } from '../../selectors/devices'
-import { useDispatch, useSelector } from 'react-redux'
 import { Box, Button, Typography } from '@mui/material'
 
-export const LoadMore: React.FC = () => {
-  const { from, size, total, results, searched, fetching } = useSelector((state: State) =>
-    selectDeviceModelAttributes(state)
-  )
-  const dispatch = useDispatch<Dispatch>()
+type Props = {
+  from: number
+  size: number
+  count: number
+  fetching: boolean
+  onLoadMore: () => void
+}
 
-  const pages = Math.ceil((searched ? results : total) / size)
+export const LoadMore: React.FC<Props> = ({ from, size, count, fetching, onLoadMore }) => {
+  const pages = Math.ceil(count / size)
   const nextPage = Math.floor(from / size) + 1
-
-  const count = searched ? results : total
   const showing = Math.min(from + size, count)
 
   if (nextPage >= pages) return null
@@ -23,7 +21,6 @@ export const LoadMore: React.FC = () => {
       sx={{
         position: 'absolute',
         display: 'flex',
-        // justifyContent: 'space-between',
         alignItems: 'center',
         padding: 3,
         paddingBottom: 4.5,
@@ -33,14 +30,7 @@ export const LoadMore: React.FC = () => {
         gap: 4,
       }}
     >
-      <Button
-        color="primary"
-        disabled={fetching}
-        onClick={() => {
-          dispatch.devices.set({ from: nextPage * size, append: true })
-          dispatch.devices.fetchList()
-        }}
-      >
+      <Button color="primary" disabled={fetching} onClick={onLoadMore}>
         {fetching ? `Loading ${from} - ${from + size}...` : 'Load More'}
       </Button>
       <Typography variant="subtitle2" color="GrayText">

--- a/frontend/src/components/LoadMore/index.ts
+++ b/frontend/src/components/LoadMore/index.ts
@@ -1,1 +1,2 @@
 export { LoadMore } from './LoadMore'
+export { DeviceLoadMore } from './DeviceLoadMore'

--- a/frontend/src/components/LoadMore/index.ts
+++ b/frontend/src/components/LoadMore/index.ts
@@ -1,2 +1,3 @@
 export { LoadMore } from './LoadMore'
 export { DeviceLoadMore } from './DeviceLoadMore'
+export { JobLoadMore } from './JobLoadMore'

--- a/frontend/src/components/OrganizationSelect.tsx
+++ b/frontend/src/components/OrganizationSelect.tsx
@@ -14,6 +14,12 @@ import { fontSizes } from '../styling'
 import { Avatar } from './Avatar'
 import { Icon } from './Icon'
 
+const CLEAR_ID_BASE: Record<string, string> = {
+  '/runs': '/runs',
+  '/script': '/scripts',
+  '/file': '/files',
+}
+
 export const OrganizationSelect: React.FC = () => {
   const css = useStyles()
   const history = useHistory()
@@ -59,8 +65,12 @@ export const OrganizationSelect: React.FC = () => {
     tags.fetchIfEmpty()
     products.fetchIfEmpty()
     partnerStats.fetchIfEmpty()
-    if (!mobile && ['/devices', '/networks', '/connections', '/products', '/partner-stats'].includes(menu)) {
+    if (mobile) return
+    if (['/devices', '/networks', '/connections', '/products', '/partner-stats'].includes(menu)) {
       history.push(defaultSelection[id]?.[menu] || menu)
+    } else if (CLEAR_ID_BASE[menu]) {
+      // Clear stale resource IDs from the URL when switching accounts
+      history.push(CLEAR_ID_BASE[menu])
     }
   }
 

--- a/frontend/src/components/ServiceList.tsx
+++ b/frontend/src/components/ServiceList.tsx
@@ -10,7 +10,7 @@ import { DeviceListContext } from '../services/Context'
 import { DeviceListItem } from './DeviceListItem'
 import { Attribute } from './Attributes'
 import { GridList } from './GridList'
-import { LoadMore } from './LoadMore'
+import { DeviceLoadMore } from './LoadMore'
 
 export interface DeviceListProps {
   attributes: Attribute[]
@@ -76,7 +76,7 @@ export const ServiceList: React.FC<DeviceListProps> = ({
           </DeviceListContext.Provider>
         )
       })}
-      <LoadMore />
+      <DeviceLoadMore />
     </GridList>
   )
 }

--- a/frontend/src/models/jobs.ts
+++ b/frontend/src/models/jobs.ts
@@ -13,6 +13,9 @@ import { RootModel } from '.'
 type ScriptsState = {
   initialized: boolean
   fetching: boolean
+  size: number
+  from: number
+  total: number
   all: {
     [accountId: string]: IJob[]
   }
@@ -21,21 +24,39 @@ type ScriptsState = {
 const defaultState: ScriptsState = {
   initialized: false,
   fetching: true,
+  size: 50,
+  from: 0,
+  total: 0,
   all: {},
 }
 
 export default createModel<RootModel>()({
   state: { ...defaultState },
   effects: dispatch => ({
-    async fetch(accountId: string | void, state) {
-      dispatch.jobs.set({ fetching: true })
-      accountId = accountId || selectActiveAccountId(state)
-      const result = await graphQLJobs(accountId)
-      if (result === 'ERROR') return
+    async fetch(args: { accountId?: string; fileID?: string; from?: number } | void, state) {
+      const accountId = args?.accountId || selectActiveAccountId(state)
+      const fileID = args?.fileID
+      const from = args?.from ?? 0
+      const { size } = state.jobs
+      dispatch.jobs.set({ fetching: true, from })
+      const fileIds = fileID ? [fileID] : undefined
+      const result = await graphQLJobs({ accountId, fileIds, from, size })
+      if (result === 'ERROR') {
+        dispatch.jobs.set({ fetching: false })
+        return
+      }
+      const total = result?.data?.data?.login?.account?.jobs?.total ?? 0
       const jobs = await dispatch.jobs.parse(result)
       console.log('LOADED JOBS', accountId, jobs)
-      dispatch.jobs.setAccount({ accountId, jobs })
-      dispatch.jobs.set({ fetching: false, initialized: true })
+      const merge = from > 0 || !!fileID
+      if (merge) dispatch.jobs.setJobs({ accountId, jobs })
+      else dispatch.jobs.setAccount({ accountId, jobs })
+      dispatch.jobs.set({ fetching: false, initialized: true, total })
+    },
+    async loadMore(args: { fileID?: string } | void, state) {
+      if (state.jobs.fetching) return
+      const { from, size } = state.jobs
+      await dispatch.jobs.fetch({ fileID: args?.fileID, from: from + size })
     },
     async fetchSingle({ accountId, jobId }: { accountId?: string; jobId: string }, state) {
       dispatch.jobs.set({ fetching: true })
@@ -47,7 +68,7 @@ export default createModel<RootModel>()({
       // }
 
       accountId = accountId || selectActiveAccountId(state)
-      const result = await graphQLJobs(accountId, undefined, [jobId])
+      const result = await graphQLJobs({ accountId, ids: [jobId] })
       if (result === 'ERROR') return
       const jobs = await dispatch.jobs.parse(result)
       console.log('LOADED JOB', accountId, jobs)
@@ -58,7 +79,7 @@ export default createModel<RootModel>()({
       dispatch.jobs.set({ fetching: true })
       accountId = accountId || selectActiveAccountId(state)
 
-      const result = await graphQLJobs(accountId, fileIds, undefined)
+      const result = await graphQLJobs({ accountId, fileIds })
       if (result === 'ERROR') return
 
       const jobs = await dispatch.jobs.parse(result)
@@ -69,7 +90,7 @@ export default createModel<RootModel>()({
     },
     async fetchIfEmpty(accountId: string | void, state) {
       accountId = accountId || selectActiveAccountId(state)
-      if (!state.jobs.all[accountId]) dispatch.jobs.fetch(accountId)
+      if (!state.jobs.all[accountId]) dispatch.jobs.fetch({ accountId })
     },
     async parse(result: AxiosResponse<any> | undefined): Promise<IJob[]> {
       const data = result?.data?.data?.login?.account

--- a/frontend/src/models/jobs.ts
+++ b/frontend/src/models/jobs.ts
@@ -209,28 +209,12 @@ export default createModel<RootModel>()({
       )
     },
     async setJobs({ accountId, jobs }: { accountId: string; jobs: IJob[] }, state) {
-      const updated = structuredClone(state.jobs.all[accountId] || [])
-
-      jobs.forEach(job => {
-        const index = updated.findIndex(j => j.id === job.id)
-        if (index === -1) updated.unshift(job)
-        else updated[index] = job
-      })
-
-      dispatch.jobs.setAccount({ accountId, jobs: updated })
+      // Prepends new entries — fetchSingle uses this so freshly-saved jobs appear at the top.
+      dispatch.jobs.setAccount({ accountId, jobs: upsertJobs(state.jobs.all[accountId], jobs, 'start') })
     },
     async appendJobs({ accountId, jobs }: { accountId: string; jobs: IJob[] }, state) {
-      // Upsert preserving server order — used for paginated and filtered fetches
-      // (setJobs unshifts new entries, which reverses pages and prepends "load older" results).
-      const updated = structuredClone(state.jobs.all[accountId] || [])
-
-      jobs.forEach(job => {
-        const index = updated.findIndex(j => j.id === job.id)
-        if (index === -1) updated.push(job)
-        else updated[index] = job
-      })
-
-      dispatch.jobs.setAccount({ accountId, jobs: updated })
+      // Appends new entries — preserves server order for paginated and filtered fetches.
+      dispatch.jobs.setAccount({ accountId, jobs: upsertJobs(state.jobs.all[accountId], jobs, 'end') })
     },
     async setAccount(params: { jobs: IJob[]; accountId: string }, state) {
       let all = structuredClone(state.jobs.all)
@@ -248,6 +232,17 @@ export default createModel<RootModel>()({
     },
   },
 })
+
+function upsertJobs(cache: IJob[] | undefined, incoming: IJob[], position: 'start' | 'end'): IJob[] {
+  const updated = structuredClone(cache || [])
+  incoming.forEach(job => {
+    const index = updated.findIndex(j => j.id === job.id)
+    if (index !== -1) updated[index] = job
+    else if (position === 'end') updated.push(job)
+    else updated.unshift(job)
+  })
+  return updated
+}
 
 function formAdaptor(form: IFileForm) {
   return {

--- a/frontend/src/models/jobs.ts
+++ b/frontend/src/models/jobs.ts
@@ -49,7 +49,7 @@ export default createModel<RootModel>()({
       const jobs = await dispatch.jobs.parse(result)
       console.log('LOADED JOBS', accountId, jobs)
       const merge = from > 0 || !!fileID
-      if (merge) dispatch.jobs.setJobs({ accountId, jobs })
+      if (merge) dispatch.jobs.appendJobs({ accountId, jobs })
       else dispatch.jobs.setAccount({ accountId, jobs })
       dispatch.jobs.set({ fetching: false, initialized: true, total })
     },
@@ -85,7 +85,7 @@ export default createModel<RootModel>()({
       const jobs = await dispatch.jobs.parse(result)
       console.log('LOADED FILE JOBS', accountId, jobs)
 
-      dispatch.jobs.setJobs({ accountId, jobs })
+      dispatch.jobs.appendJobs({ accountId, jobs })
       dispatch.jobs.set({ fetching: false })
     },
     async fetchIfEmpty(accountId: string | void, state) {
@@ -214,6 +214,19 @@ export default createModel<RootModel>()({
       jobs.forEach(job => {
         const index = updated.findIndex(j => j.id === job.id)
         if (index === -1) updated.unshift(job)
+        else updated[index] = job
+      })
+
+      dispatch.jobs.setAccount({ accountId, jobs: updated })
+    },
+    async appendJobs({ accountId, jobs }: { accountId: string; jobs: IJob[] }, state) {
+      // Upsert preserving server order — used for paginated and filtered fetches
+      // (setJobs unshifts new entries, which reverses pages and prepends "load older" results).
+      const updated = structuredClone(state.jobs.all[accountId] || [])
+
+      jobs.forEach(job => {
+        const index = updated.findIndex(j => j.id === job.id)
+        if (index === -1) updated.push(job)
         else updated[index] = job
       })
 

--- a/frontend/src/models/logs.ts
+++ b/frontend/src/models/logs.ts
@@ -4,7 +4,7 @@ import { selectActiveAccountId } from '../selectors/accounts'
 import { RootModel } from '.'
 import { store } from '../store'
 
-const DAY_MS = 24 * 60 * 60 * 1000
+export const DAY_MS = 24 * 60 * 60 * 1000
 
 type ILogState = {
   size: number

--- a/frontend/src/pages/JobsPage.tsx
+++ b/frontend/src/pages/JobsPage.tsx
@@ -23,8 +23,8 @@ export const JobsPage: React.FC = () => {
   const fetching = useSelector((state: State) => state.ui.fetching || state.jobs.fetching)
 
   useEffect(() => {
-    dispatch.jobs.fetchIfEmpty()
-  }, [accountId])
+    dispatch.jobs.fetch({ fileID })
+  }, [accountId, fileID])
 
   return (
     <ScriptingHeader>
@@ -37,7 +37,7 @@ export const JobsPage: React.FC = () => {
           </Stack>
         </Body>
       ) : (
-        <JobList attributes={attributes} {...{ required, jobs, columnWidths, fetching }} />
+        <JobList attributes={attributes} loadMore {...{ required, jobs, columnWidths, fetching }} />
       )}
     </ScriptingHeader>
   )

--- a/frontend/src/pages/ScriptPage.tsx
+++ b/frontend/src/pages/ScriptPage.tsx
@@ -161,7 +161,17 @@ export const ScriptPage: React.FC = () => {
         )}
       </Typography>
       {completedJobs.length ? (
-        <List>{completedJobs.map(renderJobRow)}</List>
+        <>
+          <List>{completedJobs.map(renderJobRow)}</List>
+          <Button
+            size="small"
+            variant="text"
+            sx={{ display: 'block', mx: 'auto', mt: 1 }}
+            onClick={() => history.push(`/runs/${fileID}`)}
+          >
+            View all runs
+          </Button>
+        </>
       ) : (
         <Notice sx={{ mx: 2 }}>No runs yet.</Notice>
       )}

--- a/frontend/src/pages/ScriptPage.tsx
+++ b/frontend/src/pages/ScriptPage.tsx
@@ -36,10 +36,11 @@ export const ScriptPage: React.FC = () => {
   // Split jobs into groups
   const readyJobs = jobs.filter(j => j.status === 'READY')
   const runningJobs = jobs.filter(j => j.status === 'RUNNING' || j.status === 'WAITING')
-  const completedJobs = [...jobs]
+  const allCompleted = [...jobs]
     .filter(j => j.status === 'SUCCESS' || j.status === 'FAILED' || j.status === 'CANCELLED')
     .sort((a, b) => new Date(b.updated).getTime() - new Date(a.updated).getTime())
-    .slice(0, MAX_RUNS)
+  const completedJobs = allCompleted.slice(0, MAX_RUNS)
+  const hasMoreRuns = allCompleted.length > completedJobs.length
 
   const args = file.versions?.[0]?.arguments
 
@@ -163,14 +164,16 @@ export const ScriptPage: React.FC = () => {
       {completedJobs.length ? (
         <>
           <List>{completedJobs.map(renderJobRow)}</List>
-          <Button
-            size="small"
-            variant="text"
-            sx={{ display: 'block', mx: 'auto', mt: 1 }}
-            onClick={() => history.push(`/runs/${fileID}`)}
-          >
-            View all runs
-          </Button>
+          {hasMoreRuns && (
+            <Button
+              size="small"
+              variant="text"
+              sx={{ display: 'block', mx: 'auto', mt: 1 }}
+              onClick={() => history.push(`/runs/${fileID}`)}
+            >
+              View all runs
+            </Button>
+          )}
         </>
       ) : (
         <Notice sx={{ mx: 2 }}>No runs yet.</Notice>

--- a/frontend/src/selectors/scripting.ts
+++ b/frontend/src/selectors/scripting.ts
@@ -18,7 +18,8 @@ export const selectFiles = createSelector([getFiles, selectActiveAccountId], (fi
 
 export const selectJobs = createSelector(
   [getJobs, selectActiveAccountId, optionalSecondParam],
-  (jobs, accountId, fileId) => (fileId ? jobs[accountId].filter(f => f.file?.id === fileId) : jobs[accountId] || [])
+  (jobs, accountId, fileId) =>
+    fileId ? (jobs[accountId] || []).filter(f => f.file?.id === fileId) : jobs[accountId] || []
 )
 
 export const selectFile = createSelector(

--- a/frontend/src/services/graphQLRequest.ts
+++ b/frontend/src/services/graphQLRequest.ts
@@ -47,12 +47,20 @@ export async function graphQLFiles(accountId: string, ids?: string[]) {
   )
 }
 
-export async function graphQLJobs(accountId: string, fileIds?: string[], ids?: string[]) {
+export async function graphQLJobs(args: {
+  accountId: string
+  fileIds?: string[]
+  ids?: string[]
+  from?: number
+  size?: number
+}) {
+  const { accountId, fileIds, ids, from, size } = args
   return await graphQLBasicRequest(
-    ` query Jobs($accountId: String, $ids: [ID!], $fileIds: [ID!]) {
+    ` query Jobs($accountId: String, $ids: [ID!], $fileIds: [ID!], $from: Int, $size: Int) {
         login {
           account(id: $accountId) {
-            jobs(ids: $ids, fileIds: $fileIds, size: 50) {
+            jobs(ids: $ids, fileIds: $fileIds, from: $from, size: $size) {
+              total
               items {
                 id
                 status
@@ -102,7 +110,7 @@ export async function graphQLJobs(accountId: string, fileIds?: string[], ids?: s
           }
         }
       }`,
-    { accountId, fileIds, ids }
+    { accountId, fileIds, ids, from, size }
   )
 }
 


### PR DESCRIPTION
## Summary
- Paginate the `/runs` page with a Load More button (50 per page); the GraphQL `jobs` query now sends `from`/`size` and reads `total`. Filtered views via `/runs/:fileID` paginate the same way.
- Add a "View all runs" text link at the bottom of the Runs section on the script page → `/runs/:fileID`.
- Show absolute date+time alongside the existing relative duration in the runs Time column.
- Refactor the existing device `LoadMore` into a presentational component shared by `DeviceLoadMore` and `JobLoadMore`.
- Fix a latent crash in `selectJobs` when the per-account cache hasn't been initialized.

## Test plan
- [ ] `/runs` loads, shows total count, Load More fetches the next 50 and merges them
- [ ] `/runs/<fileID>` filters to that script's runs and paginates independently
- [ ] Refresh button on `/runs/<fileID>` preserves the file filter
- [ ] Each row shows month-day clock-time + "X ago"
- [ ] Script page → "View all runs" navigates to `/runs/<fileID>`
- [ ] Device list and Service list Load More still work