### PR TITLE
chore(deps): bump transitive ip-address to 10.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12198,9 +12198,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary
- Bumps the root lockfile's transitive `ip-address` from 10.1.0 → 10.2.0 to clear the lingering medium-severity XSS advisory in `Address6` HTML-emitting methods.
- The package is dev-only, pulled in via `electron-builder → … → socks → ip-address`.
- #1086 already updated `/electron/package-lock.json`, but with npm workspaces the root `package-lock.json` is the operative one — `npm update ip-address` here forces it forward.

## Test plan
- [ ] `npm ci --ignore-scripts` succeeds locally
- [ ] CI typecheck + CircleCI green
- [ ] After merge, the ip-address alert auto-dismisses on the security tab