### PR TITLE
fix(runs): NaN in pagination from stale persisted state

### DIFF
--- a/frontend/src/components/LoadMore/JobLoadMore.tsx
+++ b/frontend/src/components/LoadMore/JobLoadMore.tsx
@@ -6,10 +6,11 @@ import { LoadMore } from './LoadMore'
 
 export const JobLoadMore: React.FC = () => {
   const { fileID } = useParams<{ fileID?: string }>()
-  const from = useSelector((state: State) => state.jobs.from)
-  const size = useSelector((state: State) => state.jobs.size)
-  const total = useSelector((state: State) => state.jobs.total)
-  const fetching = useSelector((state: State) => state.jobs.fetching)
+  // Fallbacks guard against persisted state from older builds that pre-date these fields.
+  const from = useSelector((state: State) => state.jobs.from ?? 0)
+  const size = useSelector((state: State) => state.jobs.size || 50)
+  const total = useSelector((state: State) => state.jobs.total ?? 0)
+  const fetching = useSelector((state: State) => state.jobs.fetching ?? false)
   const dispatch = useDispatch<Dispatch>()
 
   return (

--- a/frontend/src/models/jobs.ts
+++ b/frontend/src/models/jobs.ts
@@ -37,7 +37,7 @@ export default createModel<RootModel>()({
       const accountId = args?.accountId || selectActiveAccountId(state)
       const fileID = args?.fileID
       const from = args?.from ?? 0
-      const { size } = state.jobs
+      const size = state.jobs.size || defaultState.size
       dispatch.jobs.set({ fetching: true, from })
       const fileIds = fileID ? [fileID] : undefined
       const result = await graphQLJobs({ accountId, fileIds, from, size })
@@ -55,7 +55,8 @@ export default createModel<RootModel>()({
     },
     async loadMore(args: { fileID?: string } | void, state) {
       if (state.jobs.fetching) return
-      const { from, size } = state.jobs
+      const from = state.jobs.from ?? 0
+      const size = state.jobs.size || defaultState.size
       await dispatch.jobs.fetch({ fileID: args?.fileID, from: from + size })
     },
     async fetchSingle({ accountId, jobId }: { accountId?: string; jobId: string }, state) {


### PR DESCRIPTION
## Summary
The `/runs` Load More display showed `NaN of 31` for users with `state.jobs` persisted from a build that pre-dates the `from`/`size`/`total` fields. redux-persist's default merge is shallow, so the new keys came back undefined and the math in `LoadMore` resolved to `NaN`.

- `JobLoadMore.tsx`: default `from`/`size`/`total`/`fetching` via `??`/`||` when reading from the slice.
- `models/jobs.ts`: in `fetch` and `loadMore`, default `size`/`from` to `defaultState.size`/`0` so paginated requests still go out with sensible values.

## Test plan
- [ ] Reproduce: with a localForage entry from before the pagination PR, `/runs` shows the Load More row.
- [ ] After fix: same starting state shows correct `X of Y` and Load More works.
- [ ] Fresh install: unchanged behavior.