### PR TITLE
[codex] Fix sign-in submit and federated auth reset

### DIFF
--- a/frontend/src/cognito/components/Auth/Auth.tsx
+++ b/frontend/src/cognito/components/Auth/Auth.tsx
@@ -5,6 +5,7 @@ import {
   CognitoUser,
   ChallengeOption,
   ConfirmSignInFunc,
+  FederatedSignInFunc,
   RecoverPasswordRequestFunc,
   SendCustomChallengeAnswerFunc,
   SignInFunc,
@@ -26,9 +27,9 @@ import { Wrapper } from '../Wrapper'
 
 export type AuthProps = {
   onConfirmSignIn: ConfirmSignInFunc
-  onGoogleSignIn: () => void
-  onAppleSignIn: () => void
-  onOktaSignIn: () => void
+  onGoogleSignIn: FederatedSignInFunc
+  onAppleSignIn: FederatedSignInFunc
+  onOktaSignIn: FederatedSignInFunc
   onRecoverPasswordRequest: RecoverPasswordRequestFunc
   onSendCustomChallengeAnswer: SendCustomChallengeAnswerFunc
   onSignIn: SignInFunc
@@ -96,7 +97,7 @@ function Routes({
   }
 
   async function handleSamlSignIn(domain: string) {
-    onSamlSignIn(domain)
+    await onSamlSignIn(domain)
   }
 
   async function handleSignIn2(username: string) {

--- a/frontend/src/cognito/components/SignIn/SignIn.tsx
+++ b/frontend/src/cognito/components/SignIn/SignIn.tsx
@@ -13,7 +13,7 @@ import {
   InputAdornment,
   Collapse,
 } from '@mui/material'
-import { SignInFunc, SamlSignInFunc, UsernameChangeFunc, CheckSamlFunc } from '../../types'
+import { SignInFunc, SamlSignInFunc, UsernameChangeFunc, CheckSamlFunc, FederatedSignInFunc } from '../../types'
 import { useTranslation } from 'react-i18next'
 import { Notice } from '../../../components/Notice'
 import { Icon } from '../../../components/Icon'
@@ -39,9 +39,9 @@ export type SignInProps = {
   email?: string
   onCheckSaml: CheckSamlFunc
   onUsernameChange?: UsernameChangeFunc
-  onGoogleSignIn: () => void
-  onAppleSignIn: () => void
-  onOktaSignIn: () => void
+  onGoogleSignIn: FederatedSignInFunc
+  onAppleSignIn: FederatedSignInFunc
+  onOktaSignIn: FederatedSignInFunc
   onSignIn: SignInFunc
   onSamlSignIn: SamlSignInFunc
   showLogo?: boolean
@@ -77,6 +77,11 @@ export function SignIn({
   const passRef = React.useRef<HTMLInputElement>()
   const css = useStyles()
 
+  React.useEffect(() => {
+    setError(errorMessage ? new Error(errorMessage) : null)
+    if (errorMessage) setLoading(false)
+  }, [errorMessage])
+
   function scrollIntoView(event: React.FocusEvent<HTMLInputElement>) {
     event.target.scrollIntoView({ behavior: 'smooth', block: 'start' })
   }
@@ -85,8 +90,40 @@ export function SignIn({
     event.target.scrollIntoView({ behavior: 'smooth', block: 'end' })
   }
 
+  function getError(error: unknown): Error {
+    return error instanceof Error ? error : new Error('Sign in failed, please try again.')
+  }
+
+  function handleEnterKey(e: React.KeyboardEvent<HTMLFormElement>): void {
+    if (e.key !== 'Enter' || e.shiftKey || e.altKey || e.ctrlKey || e.metaKey) return
+
+    const target = e.target as HTMLElement
+    if (target.tagName !== 'INPUT') return
+
+    e.preventDefault()
+    e.currentTarget.requestSubmit()
+  }
+
+  async function handleFederatedSignIn(signIn: FederatedSignInFunc): Promise<void> {
+    if (loading) return
+
+    setError(null)
+    setLoading(true)
+
+    try {
+      await signIn()
+    } catch (error) {
+      console.error(error)
+      setError(getError(error))
+    } finally {
+      setLoading(false)
+    }
+  }
+
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>): Promise<void> {
     e.preventDefault()
+    if (loading) return
+
     setError(null)
 
     if (!username || (!password && emailProcessed)) return alert('Please enter a username and password')
@@ -94,8 +131,8 @@ export function SignIn({
     setLoading(true)
     if (remember) rememberMe.set({ username, emailProcessed })
 
-    if (emailProcessed) {
-      try {
+    try {
+      if (emailProcessed) {
         // await onSignIn(username, password)
         const challenge = await onSignIn(username, password)
 
@@ -116,23 +153,23 @@ export function SignIn({
 
           // TODO: handle other challenge options
         }
-      } catch (error) {
-        console.error(error)
-        setError(error)
-      }
-    } else {
-      if (username) {
-        const result = await onCheckSaml(username)
-        if (result.isSaml && result.orgName) {
-          //Its an org!
-          onSamlSignIn(result.orgName)
-        } else {
-          setEmailProcessed(true)
+      } else {
+        if (username) {
+          const result = await onCheckSaml(username)
+          if (result.isSaml && result.orgName) {
+            //Its an org!
+            await onSamlSignIn(result.orgName)
+          } else {
+            setEmailProcessed(true)
+          }
         }
       }
+    } catch (error) {
+      console.error(error)
+      setError(getError(error))
+    } finally {
+      setLoading(false)
     }
-
-    setLoading(false)
   }
 
   return (
@@ -140,18 +177,12 @@ export function SignIn({
       <Box mt={4} textAlign="center">
         <GoogleSignInButton
           fullWidth
-          onClick={() => {
-            setLoading(true)
-            onGoogleSignIn()
-          }}
+          onClick={() => handleFederatedSignIn(onGoogleSignIn)}
           disabled={loading}
         />
         <AppleSignInButton
           fullWidth
-          onClick={() => {
-            setLoading(true)
-            onAppleSignIn()
-          }}
+          onClick={() => handleFederatedSignIn(onAppleSignIn)}
           disabled={loading}
         />
       </Box>
@@ -160,7 +191,7 @@ export function SignIn({
         <Typography variant="caption">{t('pages.sign-in.or')?.toLowerCase()}</Typography>
         <Divider />
       </Box>
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={handleSubmit} onKeyDown={handleEnterKey}>
         {error?.message && (
           <Notice severity="error" fullWidth gutterBottom>
             {error.message}

--- a/frontend/src/cognito/types.d.ts
+++ b/frontend/src/cognito/types.d.ts
@@ -62,7 +62,9 @@ export type ChallengeOption =
 
 export type SignInFunc = (username: string, password?: string) => Promise<ChallengeOption | undefined>
 
-export type SamlSignInFunc = (domain: string) => Void
+export type FederatedSignInFunc = () => void | Promise<void>
+
+export type SamlSignInFunc = (domain: string) => void | Promise<void>
 
 export type UsernameChangeFunc = (email: string) => Promise<void>
 


### PR DESCRIPTION
## Summary
- Add explicit Enter-key submission for the Cognito sign-in form so Enter advances the email step and submits the password step.
- Reset sign-in loading state and surface errors when Google/Apple federated sign-in returns or fails without leaving the page.
- Sync returned sign-in errors into the sign-in component and await SAML/federated handlers through typed auth props.

## Root Cause
The sign-in view set `loading` before federated auth but had no catch/finally path if the hosted UI flow failed or returned to the same page, leaving the social buttons and form disabled. The form also relied on implicit browser submit behavior; making Enter submission explicit avoids UI/control edge cases in the multi-step Cognito form.

## Validation
- `npm run typecheck`
- `npm run build`
- Browser smoke test on `http://127.0.0.1:3003/sign-in`: Enter on email advances to password, Enter on password submits, Cognito error renders, and the form remains usable.