### PR TITLE
fix(launch): wait for connected state before auto-launching browser

### DIFF
--- a/frontend/src/buttons/LaunchButton/LaunchButton.tsx
+++ b/frontend/src/buttons/LaunchButton/LaunchButton.tsx
@@ -37,7 +37,7 @@ export const LaunchButton: React.FC<Props> = ({
 }) => {
   const dispatch = useDispatch<Dispatch>()
   const [prompt, setPrompt] = useState<boolean>(false)
-  const ready = connection?.connectLink || connection?.ready
+  const ready = connection?.connectLink || (connection?.ready && connection?.connected)
   const loading = !ready || connection?.starting || (app?.service && !app.service.loaded)
   const disabled = launchDisabled(connection) || loading
   const autoLaunch = useSelector((state: State) => state.ui.autoLaunch === connection?.id && connection?.autoLaunch)


### PR DESCRIPTION
## Summary

- Auto-launch on connect was firing as soon as the local listener bound (`ready`), but before the tunnel actually finished establishing (`connected`). This caused the browser to open against a port that wasn't yet routing traffic.
- Now gates auto-launch on `ready && connected` for local/proxy connections. ConnectLink (persistent shared URL) connections are unaffected — they still launch immediately, as they have no connecting lifecycle.

### Root cause

In [`LaunchButton.tsx`](frontend/src/buttons/LaunchButton/LaunchButton.tsx), the `ready` flag was:

```tsx
const ready = connection?.connectLink || connection?.ready
```

For a local connection, the lifecycle is:
1. `connect()` immediately sets `ui.autoLaunch = connection.id` ([connections.ts:445](frontend/src/models/connections.ts#L445))
2. Backend binds the local port → `connection.ready = true`
3. `LaunchButton` sees `autoLaunch && ready` → opens browser ❌ (too early)
4. Cloud `DEVICE_CONNECT` event arrives → `connection.connected = true` ([cloudController.ts:429](frontend/src/services/cloudController.ts#L429))

Proxy connections set `ready`, `connecting: false`, and `connected: true` atomically ([connections.ts:333-335](frontend/src/models/connections.ts#L333-L335)), so requiring `connected` doesn't regress them.

## Test plan

- [ ] Connect to a local (P2P) remote.it service with auto-launch enabled — browser should open only after the connection reports "Connected", not while still "Connecting"
- [ ] Connect via proxy connection with auto-launch enabled — browser should still open as expected
- [ ] Open a ConnectLink with auto-launch — should still launch immediately
- [ ] Verify the launch button's loading spinner now stays spinning through the full connecting → connected transition