### PR TITLE
fix(logs): drive plan upgrade notice from server limited flag

### DIFF
--- a/frontend/src/buttons/RefreshButton/RefreshButton.tsx
+++ b/frontend/src/buttons/RefreshButton/RefreshButton.tsx
@@ -7,12 +7,10 @@ import { Dispatch, State } from '../../store'
 import { VALID_JOB_ID_LENGTH } from '../../constants'
 import { useParams, useRouteMatch } from 'react-router-dom'
 import { selectDeviceModelAttributes, selectDevice } from '../../selectors/devices'
-import { selectLimit } from '../../selectors/organizations'
 import { useDispatch, useSelector } from 'react-redux'
 import { IconButton, ButtonProps } from '../IconButton'
 import { GuideBubble } from '../../components/GuideBubble'
 import { Typography } from '@mui/material'
-import { limitDays } from '../../models/plans'
 
 export const RefreshButton: React.FC<ButtonProps> = props => {
   const dispatch = useDispatch<Dispatch>()
@@ -24,7 +22,6 @@ export const RefreshButton: React.FC<ButtonProps> = props => {
     partnerId?: string
   }>()
   const device = useSelector((state: State) => selectDevice(state, undefined, deviceID))
-  const logLimit = useSelector((state: State) => selectLimit(state, undefined, 'log-limit'))
   const fetching = useSelector(
     (state: State) =>
       selectDeviceModelAttributes(state).fetching || (deviceID && state.logs.fetching) || state.ui.fetching
@@ -74,10 +71,9 @@ export const RefreshButton: React.FC<ButtonProps> = props => {
   } else if (logsPage) {
     title = device ? `Refresh ${device.name} logs` : 'Refresh logs'
     methods.push(async () => {
-      const allowedDays = Math.max(limitDays(logLimit?.value) || 0, 0)
       if (device) await dispatch.devices.fetchSingleFull({ id: device.id })
       await dispatch.logs.set({ after: undefined, maxDate: undefined })
-      await dispatch.logs.fetch({ allowedDays, deviceId: device?.id })
+      await dispatch.logs.fetch({ deviceId: device?.id })
     })
 
     // device pages

--- a/frontend/src/components/EventList/EventHeader.tsx
+++ b/frontend/src/components/EventList/EventHeader.tsx
@@ -47,7 +47,7 @@ export const EventHeader: React.FC<{ device?: IDevice }> = ({ device }) => {
       planUpgrade: false,
       minDate: minDateValue,
     })
-    fetch({ allowedDays, deviceId: device?.id })
+    fetch({ deviceId: device?.id })
   }, [activeAccount, device?.id])
 
   // Update minDate when allowedDays or device creation date changes
@@ -69,7 +69,7 @@ export const EventHeader: React.FC<{ device?: IDevice }> = ({ device }) => {
       events: { ...events, items: [] },
       planUpgrade: false,
     })
-    fetch({ allowedDays, deviceId: device?.id })
+    fetch({ deviceId: device?.id })
   }
 
   const fetchCsvUrl = () => dispatch.logs.fetchUrl(device?.id)
@@ -82,7 +82,7 @@ export const EventHeader: React.FC<{ device?: IDevice }> = ({ device }) => {
       planUpgrade: false,
     })
     setLogsFilter({ accountId: activeAccount, context: logsFilterContext, eventTypes: nextEventTypes })
-    fetch({ allowedDays, deviceId: device?.id })
+    fetch({ deviceId: device?.id })
   }
 
   return (

--- a/frontend/src/components/EventList/EventList.tsx
+++ b/frontend/src/components/EventList/EventList.tsx
@@ -6,7 +6,7 @@ import { State, Dispatch } from '../../store'
 import { useSelector, useDispatch } from 'react-redux'
 import { List, Box, Button, Typography } from '@mui/material'
 import { fontSizes, spacing } from '../../styling'
-import { humanizeDays, limitDays } from '../../models/plans'
+import { humanizeDays } from '../../models/plans'
 import { EventItem } from './EventItem'
 import { BillingUI } from '../BillingUI'
 import { Notice } from '../Notice'
@@ -23,9 +23,8 @@ export const EventList: React.FC<LogListProps> = ({ device }) => {
   const { events, planUpgrade, fetching, fetchingMore } = useSelector((state: State) => state.logs)
 
   const fetchMore = async () => {
-    const allowedDays = Math.max(limitDays(logLimit?.value) || 0, 0)
     await dispatch.logs.set({ after: events?.last })
-    await dispatch.logs.fetch({ allowedDays, deviceId: device?.id })
+    await dispatch.logs.fetch({ deviceId: device?.id })
   }
 
   const showPlanUpgradeNotice = Boolean(planUpgrade && !fetching && !fetchingMore)

--- a/frontend/src/models/logs.ts
+++ b/frontend/src/models/logs.ts
@@ -81,8 +81,9 @@ export default createModel<RootModel>()({
       }
 
       // The server reports whether older events are being withheld by the plan's
-      // log-retention limit, so the upgrade notice only shows when logs are actually hidden.
-      const planUpgrade = Boolean(nextEvents.limited)
+      // log-retention limit. Still gate on hasMore so the notice only replaces pagination
+      // once the accessible logs are exhausted — never while there's more to load.
+      const planUpgrade = !nextEvents.hasMore && Boolean(nextEvents.limited)
 
       set({
         events: nextEvents,

--- a/frontend/src/models/logs.ts
+++ b/frontend/src/models/logs.ts
@@ -44,7 +44,7 @@ const defaultState: ILogState = {
 export default createModel<RootModel>()({
   state: { ...defaultState },
   effects: dispatch => ({
-    async fetch({ allowedDays, deviceId }: { allowedDays: number; deviceId?: string }, state) {
+    async fetch({ deviceId }: { deviceId?: string }, state) {
       const { set } = dispatch.logs
       const { size, after, maxDate, minDate, events, eventTypes } = state.logs
       const accountId = selectActiveAccountId(state)
@@ -80,10 +80,9 @@ export default createModel<RootModel>()({
         items: mergedItems,
       }
 
-      const hasReachedLimit = !nextEvents.hasMore && allowedDays > 0
-      const firstLogMs = state.user.created?.getTime() || 0
-      const logLimitMs = Date.now() - allowedDays * DAY_MS
-      const planUpgrade = hasReachedLimit && firstLogMs < logLimitMs
+      // The server reports whether older events are being withheld by the plan's
+      // log-retention limit, so the upgrade notice only shows when logs are actually hidden.
+      const planUpgrade = Boolean(nextEvents.limited)
 
       set({
         events: nextEvents,

--- a/frontend/src/services/graphQLLogs.ts
+++ b/frontend/src/services/graphQLLogs.ts
@@ -3,6 +3,7 @@ import { graphQLBasicRequest } from './graphQL'
 const EVENTS = `
     events(after: $after, size: $size, minDate: $minDate, maxDate: $maxDate, types: $types) {
       hasMore
+      limited
       last
       total
       items {

--- a/types.d.ts
+++ b/types.d.ts
@@ -859,6 +859,7 @@ declare global {
     last: string
     items: IEvent[]
     hasMore: boolean
+    limited?: boolean // server indicates older events exist but are hidden by the plan log-retention limit
     deviceId?: string
   }
 


### PR DESCRIPTION
## Problem

The Logs view shows "Plan upgrade required to view logs past N" based on a **client-side heuristic** that compares the user's *account creation date* to the retention window:

```js
const planUpgrade = !hasMore && firstLogMs < logLimitMs  // firstLogMs = state.user.created
```

An old account isn't the same as "older logs exist." So the nag appeared even when nothing was actually hidden — e.g. on a device's Logs tab whose only events are recent (the account is old, but this device has no events past the window), or any account with no activity older than the limit. The client simply had no real signal.

## Change

Consume a new server-computed `limited` flag instead of guessing.

- `graphQLLogs.ts` / `types.d.ts`: request and type the new `events.limited` field.
- `models/logs.ts`: `planUpgrade = Boolean(nextEvents.limited)` — the notice now shows only when the server confirms older events are withheld by the plan. Deleted the `user.created` heuristic.
- Removed the now-dead `allowedDays` argument that only fed the heuristic from `logs.fetch` and its callers (`EventList`, `EventHeader`, `RefreshButton`). The retention-floor `minDate` the frontend sends is unchanged.

## Depends on

Server PR: https://github.com/remoteit/graphql-api/pull/105 — must deploy **first**, since the query now requests `limited`.

## Verification

`tsc --noEmit` on `frontend/` passes with 0 errors.
