### PR TITLE
fix(auth): open mobile OAuth in external browser to keep keyboard working

### DIFF
--- a/frontend/src/cognito/auth.ts
+++ b/frontend/src/cognito/auth.ts
@@ -243,7 +243,12 @@ export class AuthService {
       `scope=${this.scope.join('+')}`,
     ]
     const authUrl = `https://${this.config.cognitoAuthDomain}/oauth2/authorize?${params.join('&')}`
-    await windowOpen(authUrl, 'auth')
+    // Open the hosted UI in the external system browser rather than the in-app
+    // browser. On iOS, presenting and dismissing the in-app browser (SFSafariViewController)
+    // over the WKWebView leaves the web view unable to raise the soft keyboard, so
+    // returning to the sign-in form (e.g. after canceling) breaks email/password entry.
+    // The auth flow returns via the authCallback deep link, so an external browser works.
+    await windowOpen(authUrl, 'auth', true)
     // await this.loginWithCognito() @TODO implement with oauth2
   }
 
@@ -433,7 +438,9 @@ export class AuthService {
           `scope=${this.scope.join('+')}`,
         ]
         const logoutUrl = `https://${this.config.cognitoAuthDomain}/logout?${params.join('&')}`
-        await windowOpen(logoutUrl, 'auth')
+        // Use the external browser (see mobileAuth) so the WKWebView keyboard keeps
+        // working on the sign-in form the user returns to after signing out.
+        await windowOpen(logoutUrl, 'auth', true)
       }
       await this.cognitoAuth.signOut()
     } catch {}


### PR DESCRIPTION
## Problem

On mobile, the soft keyboard fails to appear on the sign-in form after returning from a federated (Google/Apple) sign-in attempt.

**Repro:** Tap **Sign in with Google** → cancel the OAuth page → return to the app → tap the email/password field → no keyboard.

## Root cause

Google/Apple sign-in (`mobileAuth`) and sign-out opened the Cognito hosted UI in Capacitor's **in-app browser** (`Browser.open` → `SFSafariViewController` on iOS) via `windowOpen(authUrl, 'auth')`.

On iOS, once an `SFSafariViewController` has been presented over the `WKWebView` and then dismissed (e.g. the user cancels), the underlying web view can no longer raise the soft keyboard. The fields are enabled (the `loading` reset from #1097 works correctly) — the WebView has simply lost the ability to present the keyboard. This path was introduced with the new custom auth UI in #1063.

## Fix

Open the OAuth and logout URLs in the **external system browser** instead of the embedded one (passing the existing `external` flag to `windowOpen` → `AppLauncher.openUrl`).

- The flow already returns via the `remoteit://authCallback` / `signoutCallback` deep link with the authorization-code response (`responseType = 'code'`), so the success path is unchanged.
- Using an external user-agent for OAuth also follows platform best practice (RFC 8252).
- Sign-out is changed too, since the user lands back on the same sign-in form afterward and would otherwise hit the identical issue.

## Testing notes

Needs a device/simulator check (can't run the mobile app in CI):

1. Tap Sign in with Google → cancel → confirm the email/password keyboard now works.
2. Confirm a real Google/Apple sign-in still completes and returns to the app.
3. Confirm sign-out still works.

**Expected UX change:** with the external browser, a successful sign-in won't auto-dismiss the browser tab the way the in-app browser did — the app comes to the foreground via the deep link, but the OAuth tab may remain in the background browser. This is standard for this OAuth pattern and is the tradeoff for reliable keyboard behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uj1HRmSGLKX5sa1pqY1oFY)_