### PR TITLE
Add multi-use vs one-time registration code controls on add device.

### DIFF
--- a/frontend/src/assets/ConveyorBeltBoxes.tsx
+++ b/frontend/src/assets/ConveyorBeltBoxes.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { useSelector } from 'react-redux'
+import { State } from '../store'
+
+// FontAwesome Pro 7 "conveyor-belt-boxes" (duotone solid), recolored to match
+// the platform icons (e.g. Synology) with a two-tone gray fill.
+export const ConveyorBeltBoxes: React.FC<React.SVGProps<SVGSVGElement>> = props => {
+  const darkMode = useSelector((state: State) => state.ui.themeDark)
+  const light = darkMode ? '#444' : '#bbb'
+  const dark = '#808080'
+  return (
+    <svg viewBox="0 0 640 640" version="1.1" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path
+        fill={light}
+        d="M0 480C0 533 43 576 96 576L544 576C597 576 640 533 640 480C640 427 597 384 544 384L96 384C43 384 0 427 0 480zM160 480C160 497.7 145.7 512 128 512C110.3 512 96 497.7 96 480C96 462.3 110.3 448 128 448C145.7 448 160 462.3 160 480zM352 480C352 497.7 337.7 512 320 512C302.3 512 288 497.7 288 480C288 462.3 302.3 448 320 448C337.7 448 352 462.3 352 480zM544 480C544 497.7 529.7 512 512 512C494.3 512 480 497.7 480 480C480 462.3 494.3 448 512 448C529.7 448 544 462.3 544 480z"
+      />
+      <path
+        fill={dark}
+        d="M64 112C64 85.5 85.5 64 112 64L272 64C298.5 64 320 85.5 320 112L320 272C320 298.5 298.5 320 272 320L112 320C85.5 320 64 298.5 64 272L64 112zM96 480C96 462.3 110.3 448 128 448C145.7 448 160 462.3 160 480C160 497.7 145.7 512 128 512C110.3 512 96 497.7 96 480zM288 480C288 462.3 302.3 448 320 448C337.7 448 352 462.3 352 480C352 497.7 337.7 512 320 512C302.3 512 288 497.7 288 480zM512 448C529.7 448 544 462.3 544 480C544 497.7 529.7 512 512 512C494.3 512 480 497.7 480 480C480 462.3 494.3 448 512 448zM432 128L528 128C554.5 128 576 149.5 576 176L576 272C576 298.5 554.5 320 528 320L432 320C405.5 320 384 298.5 384 272L384 176C384 149.5 405.5 128 432 128z"
+      />
+    </svg>
+  )
+}

--- a/frontend/src/components/AddDevice.tsx
+++ b/frontend/src/components/AddDevice.tsx
@@ -12,14 +12,16 @@ type Props = {
   tags?: string[]
   redirect?: string
   minimal?: boolean
+  oneTimeUse?: boolean
 }
 
-export const AddDevice: React.FC<Props> = ({ platform, tags, serviceTypes, redirect, minimal }) => {
+export const AddDevice: React.FC<Props> = ({ platform, tags, serviceTypes, redirect, minimal, oneTimeUse }) => {
   const { registrationCode, registrationCommand, redirectUrl, fetching } = useAutoRegistration({
     platform,
     tags,
     serviceTypes,
     redirect,
+    oneTimeUse,
   })
   const codeOnly = platform.installation?.command === '[CODE]'
 

--- a/frontend/src/components/AddPlatformTags.tsx
+++ b/frontend/src/components/AddPlatformTags.tsx
@@ -8,7 +8,7 @@ import { selectTags } from '../selectors/tags'
 import { TagEditor } from './TagEditor'
 import { Tags } from './Tags'
 
-type Props = StackProps & { button?: string; tags: string[]; onChange: (tags: string[]) => void }
+type Props = Omit<StackProps, 'onChange'> & { button?: string; tags: string[]; onChange: (tags: string[]) => void }
 
 export const AddPlatformTags: React.FC<Props> = ({ button, tags, onChange, ...props }) => {
   const { allTags, accountId, canEdit } = useSelector((state: State) => ({

--- a/frontend/src/components/DeviceOptionMenu.tsx
+++ b/frontend/src/components/DeviceOptionMenu.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { PROTOCOL } from '../constants'
 import { Dispatch } from '../store'
 import { useDispatch } from 'react-redux'
-import { Link, useParams } from 'react-router-dom'
+import { Link, useParams, useHistory } from 'react-router-dom'
 import { Divider, Menu, MenuItem, ListItemIcon, ListItemText } from '@mui/material'
 import { DeleteServiceMenuItem } from '../buttons/DeleteServiceMenuItem'
 import { ListItemLocation } from './ListItemLocation'
@@ -18,6 +18,7 @@ type Props = { device?: IDevice; service?: IService; user?: IUser }
 
 export const DeviceOptionMenu: React.FC<Props> = ({ device, service }) => {
   const { deviceID } = useParams<{ deviceID?: string }>()
+  const history = useHistory()
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
   const handleClick = event => setAnchorEl(event.currentTarget)
   const handleClose = () => setAnchorEl(null)
@@ -26,6 +27,21 @@ export const DeviceOptionMenu: React.FC<Props> = ({ device, service }) => {
   const deviceOnly = device && !service
 
   if (!device) return null
+
+  const handleMakeProduct = async () => {
+    handleClose()
+    const product = await dispatch.products.createFromRegistration({
+      platform: device.targetPlatform,
+      tags: device.tags?.map(t => t.name),
+      services: device.services.map(s => ({
+        application: s.typeID,
+        name: s.name,
+        port: s.port,
+        enabled: s.enabled,
+      })),
+    })
+    if (product) history.push(`/products/${product.id}/details`)
+  }
 
   return (
     <>
@@ -98,6 +114,12 @@ export const DeviceOptionMenu: React.FC<Props> = ({ device, service }) => {
                 <Icon name="arrow-turn-down-right" size="md" />
               </ListItemIcon>
               <ListItemText primary="Transfer Device" />
+            </MenuItem>,
+            <MenuItem dense key="makeProduct" onClick={handleMakeProduct}>
+              <ListItemIcon>
+                <Icon name="conveyor-belt-boxes" size="md" />
+              </ListItemIcon>
+              <ListItemText primary="Make Product" />
             </MenuItem>,
           ]}
         {device.permissions.includes('MANAGE') &&

--- a/frontend/src/components/ProductAttributes.tsx
+++ b/frontend/src/components/ProductAttributes.tsx
@@ -1,7 +1,6 @@
 import { Chip, Typography } from '@mui/material'
 import React from 'react'
 import { Attribute } from './Attributes'
-import { ProductStatusChip } from './ProductStatusChip'
 import { Timestamp } from './Timestamp'
 
 export class ProductAttribute extends Attribute<IDataOptions> {
@@ -35,12 +34,6 @@ export const productAttributes: ProductAttribute[] = [
         {product?.platform?.name || product?.platform?.id}
       </Typography>
     ),
-  }),
-  new ProductAttribute({
-    id: 'productStatus',
-    label: 'Status',
-    defaultWidth: 100,
-    value: ({ product }: IDataOptions) => <ProductStatusChip status={product?.status} />,
   }),
   new ProductAttribute({
     id: 'productServices',
@@ -81,11 +74,6 @@ export const productDetailAttributes: ProductDetailAttribute[] = [
     id: 'productPlatformDetail',
     label: 'Platform',
     value: ({ product }: IDataOptions) => product?.platform?.name || product?.platform?.id,
-  }),
-  new ProductDetailAttribute({
-    id: 'productStatusDetail',
-    label: 'Status',
-    value: ({ product }: IDataOptions) => <ProductStatusChip status={product?.status} />,
   }),
   new ProductDetailAttribute({
     id: 'productServicesDetail',

--- a/frontend/src/components/ProductTagEditor.tsx
+++ b/frontend/src/components/ProductTagEditor.tsx
@@ -34,12 +34,7 @@ export const ProductTagEditor: React.FC<Props> = ({ product, button }) => {
       />
       {canEdit && (
         <TagEditor
-          onCreate={async tag => {
-            await dispatch.tags.create({ tag, accountId })
-            if (!productTagNames.includes(tag.name)) {
-              updateTags([...productTagNames, tag.name])
-            }
-          }}
+          onCreate={async tag => await dispatch.tags.create({ tag, accountId })}
           onSelect={tag => {
             if (!productTagNames.includes(tag.name)) {
               updateTags([...productTagNames, tag.name])

--- a/frontend/src/components/ProductTagEditor.tsx
+++ b/frontend/src/components/ProductTagEditor.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { Dispatch, State } from '../store'
+import { selectActiveAccountId } from '../selectors/accounts'
+import { canEditTags } from '../models/tags'
+import { selectTags } from '../selectors/tags'
+import { IDeviceProduct } from '../models/products'
+import { TagEditor } from './TagEditor'
+import { Tags } from './Tags'
+
+type Props = { product?: IDeviceProduct; button?: string }
+
+export const ProductTagEditor: React.FC<Props> = ({ product, button }) => {
+  const accountId = useSelector((state: State) => selectActiveAccountId(state))
+  const allTags = useSelector((state: State) => selectTags(state, accountId))
+  const canEdit = useSelector((state: State) => canEditTags(state, accountId))
+  const dispatch = useDispatch<Dispatch>()
+
+  if (!product) return null
+
+  const productTagNames = product.tags || []
+  const productTags = allTags.filter(t => productTagNames.includes(t.name))
+
+  const updateTags = (tags: string[]) => {
+    dispatch.products.updateProduct({ id: product.id, input: { tags } })
+  }
+
+  return (
+    <>
+      <Tags
+        showEmpty={!canEdit}
+        tags={productTags}
+        onDelete={canEdit ? tag => updateTags(productTagNames.filter(t => t !== tag.name)) : undefined}
+      />
+      {canEdit && (
+        <TagEditor
+          onCreate={async tag => {
+            await dispatch.tags.create({ tag, accountId })
+            if (!productTagNames.includes(tag.name)) {
+              updateTags([...productTagNames, tag.name])
+            }
+          }}
+          onSelect={tag => {
+            if (!productTagNames.includes(tag.name)) {
+              updateTags([...productTagNames, tag.name])
+            }
+          }}
+          tags={allTags}
+          filter={productTags}
+          button={button}
+        />
+      )}
+    </>
+  )
+}

--- a/frontend/src/components/RentANodeRequest.tsx
+++ b/frontend/src/components/RentANodeRequest.tsx
@@ -13,8 +13,8 @@ const NodeAttribute = ({ label, ...props }: IconProps & { label: string }) => (
   </Typography>
 )
 
-export const RentANodeRequest: React.FC<IPlatformOverrideProps> = ({ platform, tags, serviceTypes }) => {
-  const { registrationCode } = useAutoRegistration({ platform, tags, serviceTypes })
+export const RentANodeRequest: React.FC<IPlatformOverrideProps> = ({ platform, tags, serviceTypes, oneTimeUse }) => {
+  const { registrationCode } = useAutoRegistration({ platform, tags, serviceTypes, oneTimeUse })
   return (
     <>
       <OrganizationIndicator avatarSize={42} marginBottom={3} display="inline-flex" />

--- a/frontend/src/hooks/useAutoRegistration.ts
+++ b/frontend/src/hooks/useAutoRegistration.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { windowOpen } from '../services/browser'
 import { State, Dispatch } from '../store'
 import { platforms, IPlatform } from '../platforms'
@@ -15,10 +15,13 @@ type Props = {
 
 export function useAutoRegistration({ platform, tags, serviceTypes, redirect, oneTimeUse }: Props) {
   const organization = useSelector((state: State) => selectOrganization(state))
-  const registrationCommand = useSelector((state: State) => state.ui.registrationCommand)
-  const registrationCode = useSelector((state: State) => state.ui.registrationCode)
   const fetching = useSelector((state: State) => state.ui.fetching)
   const user = useSelector((state: State) => state.user)
+
+  const [registrationCode, setRegistrationCode] = useState<string>()
+  const [registrationCommand, setRegistrationCommand] = useState<string>()
+  const sessionCodeRef = useRef<string>()
+  const sessionContextRef = useRef<{ accountId: string; platformId?: string }>()
 
   const [redirected, setRedirected] = useState<boolean>(false)
   const dispatch = useDispatch<Dispatch>()
@@ -41,26 +44,47 @@ export function useAutoRegistration({ platform, tags, serviceTypes, redirect, on
       accountId,
     })
     if (fetching) return
+
+    const platformId = platform?.id
+    const previousContext = sessionContextRef.current
+
+    if (
+      previousContext &&
+      (previousContext.accountId !== accountId || previousContext.platformId !== platformId)
+    ) {
+      sessionCodeRef.current = undefined
+      setRegistrationCode(undefined)
+      setRegistrationCommand(undefined)
+    }
+
+    sessionContextRef.current = { accountId, platformId }
+
     ;(async () => {
       let options: Parameters<typeof dispatch.devices.createRegistration>[0] = {
         tags,
         accountId,
         services: serviceTypes.map(type => ({ application: type })),
         oneTimeUse,
-        code: registrationCode,
+        code: sessionCodeRef.current,
       }
       if (platform) {
         options.platform = platforms.findType(platform.id)
         options.template = platform.installation?.command
       }
 
-      const code = await dispatch.devices.createRegistration(options)
+      const result = await dispatch.devices.createRegistration(options)
+
+      if (result) {
+        sessionCodeRef.current = result.registrationCode
+        setRegistrationCode(result.registrationCode)
+        setRegistrationCommand(result.registrationCommand)
+      }
 
       if (!redirect || redirected) return
 
       try {
         setRedirected(true)
-        const url = getRedirect(redirect, code)
+        const url = getRedirect(redirect, result?.registrationCode)
         console.log('REDIRECT TO:', url)
         windowOpen(url, '_blank', true)
       } catch (error) {
@@ -71,7 +95,8 @@ export function useAutoRegistration({ platform, tags, serviceTypes, redirect, on
 
   useEffect(() => {
     return () => {
-      dispatch.ui.set({ registrationCommand: undefined })
+      sessionCodeRef.current = undefined
+      dispatch.ui.set({ registrationCommand: undefined, registrationCode: undefined })
     }
   }, [dispatch])
 

--- a/frontend/src/hooks/useAutoRegistration.ts
+++ b/frontend/src/hooks/useAutoRegistration.ts
@@ -10,9 +10,10 @@ type Props = {
   platform?: IPlatform
   tags?: string[]
   redirect?: string
+  oneTimeUse?: boolean
 }
 
-export function useAutoRegistration({ platform, tags, serviceTypes, redirect }: Props) {
+export function useAutoRegistration({ platform, tags, serviceTypes, redirect, oneTimeUse }: Props) {
   const organization = useSelector((state: State) => selectOrganization(state))
   const registrationCommand = useSelector((state: State) => state.ui.registrationCommand)
   const registrationCode = useSelector((state: State) => state.ui.registrationCode)
@@ -45,6 +46,8 @@ export function useAutoRegistration({ platform, tags, serviceTypes, redirect }: 
         tags,
         accountId,
         services: serviceTypes.map(type => ({ application: type })),
+        oneTimeUse,
+        code: registrationCode,
       }
       if (platform) {
         options.platform = platforms.findType(platform.id)
@@ -64,11 +67,13 @@ export function useAutoRegistration({ platform, tags, serviceTypes, redirect }: 
         console.warn('Failed to redirect to:', error)
       }
     })()
+  }, [accountId, platform, tags?.length, serviceTypes.length, fetching, oneTimeUse])
 
-    return function cleanup() {
-      dispatch.ui.set({ registrationCommand: undefined }) // remove registration code so we don't redirect to new device page
+  useEffect(() => {
+    return () => {
+      dispatch.ui.set({ registrationCommand: undefined })
     }
-  }, [accountId, platform, tags?.length, serviceTypes.length, fetching])
+  }, [dispatch])
 
   return { registrationCommand, registrationCode, redirectUrl: getRedirect(redirect, registrationCode), fetching }
 }

--- a/frontend/src/models/backend.ts
+++ b/frontend/src/models/backend.ts
@@ -123,16 +123,17 @@ export default createModel<RootModel>()({
     },
     async registerDevice({ services, name, accountId }: { services: IService[]; name: string; accountId: string }) {
       dispatch.ui.set({ setupRegisteringDevice: true })
-      const code = await dispatch.devices.createRegistration({
-        name,
-        accountId,
-        services: services.map(t => ({
-          name: t.name,
-          application: t.typeID,
-          port: t.port,
-          host: t.host,
-        })),
-      })
+      const { registrationCode: code } =
+        (await dispatch.devices.createRegistration({
+          name,
+          accountId,
+          services: services.map(t => ({
+            name: t.name,
+            application: t.typeID,
+            port: t.port,
+            host: t.host,
+          })),
+        })) || {}
       emit('registration', code)
     },
     async setUpdateNotice(updateVersion: string | undefined, state) {

--- a/frontend/src/models/devices.ts
+++ b/frontend/src/models/devices.ts
@@ -543,6 +543,8 @@ export default createModel<RootModel>()({
       tags,
       accountId,
       template,
+      oneTimeUse,
+      code,
     }: {
       name?: string
       services: IServiceRegistration[]
@@ -550,14 +552,21 @@ export default createModel<RootModel>()({
       tags?: string[]
       accountId: string
       template?: string | boolean
-    }) {
+      oneTimeUse?: boolean
+      code?: string
+    }, state) {
       if (platform === 65535) platform = undefined // Clear out the platform if it's the unknown type
-      const result = await graphQLRegistration({ name, services, platform, tags, accountId })
+      const result = await graphQLRegistration({ name, services, platform, tags, accountId, oneTimeUse, code })
       if (result !== 'ERROR') {
         let { registrationCommand, registrationCode } = result?.data?.data?.login?.account
         if (template && typeof template === 'string') registrationCommand = template.replace('[CODE]', registrationCode)
         console.log('CREATE REGISTRATION', registrationCode)
-        dispatch.ui.set({ registrationCommand, registrationCode })
+        if (
+          state.ui.registrationCode !== registrationCode ||
+          state.ui.registrationCommand !== registrationCommand
+        ) {
+          dispatch.ui.set({ registrationCommand, registrationCode })
+        }
         return registrationCode
       }
     },

--- a/frontend/src/models/devices.ts
+++ b/frontend/src/models/devices.ts
@@ -567,7 +567,7 @@ export default createModel<RootModel>()({
         ) {
           dispatch.ui.set({ registrationCommand, registrationCode })
         }
-        return registrationCode
+        return { registrationCode, registrationCommand }
       }
     },
 

--- a/frontend/src/models/products.ts
+++ b/frontend/src/models/products.ts
@@ -5,10 +5,11 @@ import {
   graphQLDeviceProduct,
   graphQLCreateDeviceProduct,
   graphQLDeleteDeviceProduct,
-  graphQLUpdateDeviceProductSettings,
   graphQLAddDeviceProductService,
   graphQLRemoveDeviceProductService,
   graphQLTransferDeviceProduct,
+  graphQLCreateDeviceProductFromRegistration,
+  graphQLUpdateDeviceProduct,
 } from '../services/graphQLDeviceProducts'
 import { graphQLGetErrors } from '../services/graphQL'
 import { selectActiveAccountId } from '../selectors/accounts'
@@ -29,6 +30,8 @@ export interface IDeviceProduct {
   status: 'NEW' | 'LOCKED'
   registrationCode?: string
   registrationCommand?: string
+  tags?: string[]
+  source?: string
   created: string
   updated: string
   services: IProductService[]
@@ -185,23 +188,6 @@ export default createModel<RootModel>()({
       dispatch.products.set({ selected: [], accountId })
     },
 
-    async updateSettings({ id, input }: { id: string; input: { lock?: boolean } }, state) {
-      const accountId = selectActiveAccountId(state)
-      const response = await graphQLUpdateDeviceProductSettings(id, input)
-      if (response !== 'ERROR' && !graphQLGetErrors(response)) {
-        const updatedProduct = response?.data?.data?.updateDeviceProductSettings
-        if (updatedProduct) {
-          const productModel = getProductModel(state, accountId)
-          dispatch.products.set({
-            all: productModel.all.map(p => (p.id === id ? updatedProduct : p)),
-            accountId,
-          })
-        }
-        return updatedProduct
-      }
-      return null
-    },
-
     async addService(
       { productId, input }: { productId: string; input: { name: string; type: string; port: number; enabled: boolean } },
       state
@@ -220,6 +206,50 @@ export default createModel<RootModel>()({
           })
         }
         return newService
+      }
+      return null
+    },
+
+    async createFromRegistration(
+      input: {
+        platform: number
+        tags?: string[]
+        services: { application: number; name?: string; port?: number; enabled?: boolean }[]
+      },
+      state
+    ) {
+      const accountId = selectActiveAccountId(state)
+      const response = await graphQLCreateDeviceProductFromRegistration({ ...input, accountId })
+      if (response !== 'ERROR' && !graphQLGetErrors(response)) {
+        const newProduct = response?.data?.data?.createDeviceProductFromRegistration
+        if (newProduct) {
+          const productModel = getProductModel(state, accountId)
+          dispatch.products.set({
+            all: [...productModel.all, newProduct],
+            accountId,
+          })
+          return newProduct
+        }
+      }
+      return null
+    },
+
+    async updateProduct(
+      { id, input }: { id: string; input: { name?: string; platform?: number; tags?: string[] } },
+      state
+    ) {
+      const accountId = selectActiveAccountId(state)
+      const response = await graphQLUpdateDeviceProduct(id, input)
+      if (response !== 'ERROR' && !graphQLGetErrors(response)) {
+        const updatedProduct = response?.data?.data?.updateDeviceProduct
+        if (updatedProduct) {
+          const productModel = getProductModel(state, accountId)
+          dispatch.products.set({
+            all: productModel.all.map(p => (p.id === id ? updatedProduct : p)),
+            accountId,
+          })
+        }
+        return updatedProduct
       }
       return null
     },

--- a/frontend/src/pages/AddPage.tsx
+++ b/frontend/src/pages/AddPage.tsx
@@ -18,6 +18,7 @@ import { platforms } from '../platforms'
 import { spacing } from '../styling'
 import { Title } from '../components/Title'
 import { Icon } from '../components/Icon'
+import { ConveyorBeltBoxes } from '../assets/ConveyorBeltBoxes'
 
 export const AddPage: React.FC = () => {
   const css = useStyles()
@@ -119,10 +120,10 @@ export const AddPage: React.FC = () => {
         </List>
         <ClaimDevice className={classnames(css.list, css.smallList)} />
         <List className={classnames(css.list, css.smallList)} dense disablePadding>
-          <ListSubheader disableGutters>Add from product</ListSubheader>
+          <ListSubheader disableGutters>Add many</ListSubheader>
           <ListItemButton disableGutters onClick={() => history.push('/products')}>
             <ListItemIcon>
-              <Icon name="conveyor-belt-boxes" size="xxl" color="grayDarker" fixedWidth />
+              <ConveyorBeltBoxes style={{ height: '2.25rem', width: 'auto' }} />
             </ListItemIcon>
             <ListItemText primary="Products" secondary="Provision in bulk" />
           </ListItemButton>

--- a/frontend/src/pages/AddPage.tsx
+++ b/frontend/src/pages/AddPage.tsx
@@ -118,6 +118,15 @@ export const AddPage: React.FC = () => {
           })}
         </List>
         <ClaimDevice className={classnames(css.list, css.smallList)} />
+        <List className={classnames(css.list, css.smallList)} dense disablePadding>
+          <ListSubheader disableGutters>Add from product</ListSubheader>
+          <ListItemButton disableGutters onClick={() => history.push('/products')}>
+            <ListItemIcon>
+              <Icon name="conveyor-belt-boxes" size="xxl" color="grayDarker" fixedWidth />
+            </ListItemIcon>
+            <ListItemText primary="Products" secondary="Provision in bulk" />
+          </ListItemButton>
+        </List>
       </Stack>
     </Container>
   )

--- a/frontend/src/pages/PlatformAddPage.tsx
+++ b/frontend/src/pages/PlatformAddPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { useSelector } from 'react-redux'
-import { useMediaQuery, Typography, Box, Stack, Divider, Theme } from '@mui/material'
+import { useMediaQuery, Typography, Box, Stack, Divider, Theme, Chip } from '@mui/material'
 import { AddPlatformServices } from '../components/AddPlatformServices'
 import { selectPermissions } from '../selectors/organizations'
 import { AddPlatformTags } from '../components/AddPlatformTags'
@@ -19,6 +19,7 @@ export const PlatformAddPage: React.FC = () => {
   const permissions = useSelector(selectPermissions)
   const [platformTags, setPlatformTags] = useState<string[]>([])
   const [serviceTypes, setServiceTypes] = useState<number[]>(defaultServices)
+  const [oneTimeUse, setOneTimeUse] = useState(false)
   const xs = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'))
 
   return (
@@ -52,6 +53,24 @@ export const PlatformAddPage: React.FC = () => {
                 onChange={tags => setPlatformTags(tags)}
                 alignItems={{ xs: 'flex-start', md: 'flex-end' }}
               />
+              <Stack alignItems={{ xs: 'flex-start', md: 'flex-end' }} marginTop={2}>
+                <Chip
+                  label={oneTimeUse ? 'ONE-TIME USE' : 'MULTI USE'}
+                  size="small"
+                  color={oneTimeUse ? 'primary' : 'default'}
+                  variant={oneTimeUse ? 'filled' : 'outlined'}
+                  onClick={() => setOneTimeUse(!oneTimeUse)}
+                  sx={{
+                    fontWeight: 500,
+                    letterSpacing: 1,
+                    color: oneTimeUse ? undefined : 'grayDarker.main',
+                    whiteSpace: 'nowrap',
+                    width: '100%',
+                    minWidth: 130,
+                    '& .MuiChip-label': { width: '100%', textAlign: 'center', px: 0 },
+                  }}
+                />
+              </Stack>
             </Stack>
           )}
         </Stack>
@@ -77,7 +96,7 @@ export const PlatformAddPage: React.FC = () => {
           ) : platformObj.override ? (
             <platformObj.override platform={platformObj} tags={platformTags} serviceTypes={serviceTypes} />
           ) : platformObj.installation?.command && !platformObj.installation?.download ? (
-            <AddDevice platform={platformObj} tags={platformTags} serviceTypes={serviceTypes} redirect={redirect} />
+            <AddDevice platform={platformObj} tags={platformTags} serviceTypes={serviceTypes} redirect={redirect} oneTimeUse={oneTimeUse} />
           ) : (
             <>
               <AddDownload platform={platformObj} />
@@ -91,6 +110,7 @@ export const PlatformAddPage: React.FC = () => {
                     tags={platformTags}
                     serviceTypes={serviceTypes}
                     redirect={redirect}
+                    oneTimeUse={oneTimeUse}
                     minimal
                   />
                 </>

--- a/frontend/src/pages/PlatformAddPage.tsx
+++ b/frontend/src/pages/PlatformAddPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, useHistory } from 'react-router-dom'
 import { useSelector } from 'react-redux'
-import { useMediaQuery, Typography, Box, Stack, Divider, Theme, Chip } from '@mui/material'
+import { useMediaQuery, Typography, Box, Stack, Divider, Theme, Chip, Button } from '@mui/material'
 import { AddPlatformServices } from '../components/AddPlatformServices'
 import { selectPermissions } from '../selectors/organizations'
 import { AddPlatformTags } from '../components/AddPlatformTags'
@@ -11,16 +11,33 @@ import { platforms } from '../platforms'
 import { Notice } from '../components/Notice'
 import { Body } from '../components/Body'
 import { Icon } from '../components/Icon'
+import { dispatch } from '../store'
 
 export const PlatformAddPage: React.FC = () => {
   let { platform = '', redirect } = useParams<{ platform?: string; redirect?: string }>()
+  const history = useHistory()
   const platformObj = platforms.get(platform)
   const defaultServices = platformObj.services ? platformObj.services.map(s => s.application) : [28]
   const permissions = useSelector(selectPermissions)
   const [platformTags, setPlatformTags] = useState<string[]>([])
   const [serviceTypes, setServiceTypes] = useState<number[]>(defaultServices)
   const [oneTimeUse, setOneTimeUse] = useState(false)
+  const [creatingProduct, setCreatingProduct] = useState(false)
   const xs = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'))
+
+  const handleMakeProduct = async () => {
+    const platformCode = platforms.findType(platformObj.id)
+    if (!platformCode || serviceTypes.length === 0) return
+
+    setCreatingProduct(true)
+    const product = await dispatch.products.createFromRegistration({
+      platform: platformCode,
+      tags: platformTags,
+      services: serviceTypes.map(type => ({ application: type })),
+    })
+    setCreatingProduct(false)
+    if (product) history.push(`/products/${product.id}/details`)
+  }
 
   return (
     <Body center>
@@ -53,7 +70,7 @@ export const PlatformAddPage: React.FC = () => {
                 onChange={tags => setPlatformTags(tags)}
                 alignItems={{ xs: 'flex-start', md: 'flex-end' }}
               />
-              <Stack alignItems={{ xs: 'flex-start', md: 'flex-end' }} marginTop={2}>
+              <Stack alignItems={{ xs: 'flex-start', md: 'flex-end' }} marginTop={2} spacing={1} width="100%">
                 <Chip
                   label={oneTimeUse ? 'ONE-TIME USE' : 'MULTI USE'}
                   size="small"
@@ -70,6 +87,21 @@ export const PlatformAddPage: React.FC = () => {
                     '& .MuiChip-label': { width: '100%', textAlign: 'center', px: 0 },
                   }}
                 />
+                <Button
+                  size="small"
+                  variant="outlined"
+                  disabled={creatingProduct || serviceTypes.length === 0}
+                  onClick={handleMakeProduct}
+                  sx={{
+                    fontWeight: 500,
+                    letterSpacing: 1,
+                    whiteSpace: 'nowrap',
+                    width: '100%',
+                    minWidth: 130,
+                  }}
+                >
+                  MAKE PRODUCT
+                </Button>
               </Stack>
             </Stack>
           )}

--- a/frontend/src/pages/PlatformAddPage.tsx
+++ b/frontend/src/pages/PlatformAddPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
-import { useParams, useHistory } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { useSelector } from 'react-redux'
-import { useMediaQuery, Typography, Box, Stack, Divider, Theme, Chip, Button } from '@mui/material'
+import { useMediaQuery, Typography, Box, Stack, Divider, Theme, Chip } from '@mui/material'
 import { AddPlatformServices } from '../components/AddPlatformServices'
 import { selectPermissions } from '../selectors/organizations'
 import { AddPlatformTags } from '../components/AddPlatformTags'
@@ -11,33 +11,16 @@ import { platforms } from '../platforms'
 import { Notice } from '../components/Notice'
 import { Body } from '../components/Body'
 import { Icon } from '../components/Icon'
-import { dispatch } from '../store'
 
 export const PlatformAddPage: React.FC = () => {
   let { platform = '', redirect } = useParams<{ platform?: string; redirect?: string }>()
-  const history = useHistory()
   const platformObj = platforms.get(platform)
   const defaultServices = platformObj.services ? platformObj.services.map(s => s.application) : [28]
   const permissions = useSelector(selectPermissions)
   const [platformTags, setPlatformTags] = useState<string[]>([])
   const [serviceTypes, setServiceTypes] = useState<number[]>(defaultServices)
   const [oneTimeUse, setOneTimeUse] = useState(false)
-  const [creatingProduct, setCreatingProduct] = useState(false)
   const xs = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'))
-
-  const handleMakeProduct = async () => {
-    const platformCode = platforms.findType(platformObj.id)
-    if (!platformCode || serviceTypes.length === 0) return
-
-    setCreatingProduct(true)
-    const product = await dispatch.products.createFromRegistration({
-      platform: platformCode,
-      tags: platformTags,
-      services: serviceTypes.map(type => ({ application: type })),
-    })
-    setCreatingProduct(false)
-    if (product) history.push(`/products/${product.id}/details`)
-  }
 
   return (
     <Body center>
@@ -70,38 +53,21 @@ export const PlatformAddPage: React.FC = () => {
                 onChange={tags => setPlatformTags(tags)}
                 alignItems={{ xs: 'flex-start', md: 'flex-end' }}
               />
-              <Stack alignItems={{ xs: 'flex-start', md: 'flex-end' }} marginTop={2} spacing={1} width="100%">
+              <Stack alignItems={{ xs: 'flex-start', md: 'flex-end' }} marginTop={2} width="100%">
                 <Chip
                   label={oneTimeUse ? 'ONE-TIME USE' : 'MULTI USE'}
                   size="small"
                   color={oneTimeUse ? 'primary' : 'default'}
-                  variant={oneTimeUse ? 'filled' : 'outlined'}
                   onClick={() => setOneTimeUse(!oneTimeUse)}
                   sx={{
                     fontWeight: 500,
                     letterSpacing: 1,
                     color: oneTimeUse ? undefined : 'grayDarker.main',
                     whiteSpace: 'nowrap',
-                    width: '100%',
-                    minWidth: 130,
+                    width: 120,
                     '& .MuiChip-label': { width: '100%', textAlign: 'center', px: 0 },
                   }}
                 />
-                <Button
-                  size="small"
-                  variant="outlined"
-                  disabled={creatingProduct || serviceTypes.length === 0}
-                  onClick={handleMakeProduct}
-                  sx={{
-                    fontWeight: 500,
-                    letterSpacing: 1,
-                    whiteSpace: 'nowrap',
-                    width: '100%',
-                    minWidth: 130,
-                  }}
-                >
-                  MAKE PRODUCT
-                </Button>
               </Stack>
             </Stack>
           )}

--- a/frontend/src/pages/PlatformAddPage.tsx
+++ b/frontend/src/pages/PlatformAddPage.tsx
@@ -126,7 +126,7 @@ export const PlatformAddPage: React.FC = () => {
               <Notice>You must have the register permission to add a device to this organization.</Notice>
             </Box>
           ) : platformObj.override ? (
-            <platformObj.override platform={platformObj} tags={platformTags} serviceTypes={serviceTypes} />
+            <platformObj.override platform={platformObj} tags={platformTags} serviceTypes={serviceTypes} oneTimeUse={oneTimeUse} />
           ) : platformObj.installation?.command && !platformObj.installation?.download ? (
             <AddDevice platform={platformObj} tags={platformTags} serviceTypes={serviceTypes} redirect={redirect} oneTimeUse={oneTimeUse} />
           ) : (

--- a/frontend/src/pages/ProductsPage/ProductPage.tsx
+++ b/frontend/src/pages/ProductsPage/ProductPage.tsx
@@ -10,8 +10,8 @@ import { Body } from '../../components/Body'
 import { Notice } from '../../components/Notice'
 import { IconButton } from '../../buttons/IconButton'
 import { LoadingMessage } from '../../components/LoadingMessage'
-import { ProductStatusChip } from '../../components/ProductStatusChip'
 import { ColorChip } from '../../components/ColorChip'
+import { ProductTagEditor } from '../../components/ProductTagEditor'
 import { dispatch } from '../../store'
 import { getProductModel } from '../../selectors/products'
 import { spacing } from '../../styling'
@@ -23,14 +23,15 @@ export const ProductPage: React.FC = () => {
   const { all: products, fetching, initialized } = useSelector(getProductModel)
   const product = products.find(p => p.id === productId)
 
-  const isLocked = product?.status === 'LOCKED'
-
-  // Refresh product data when loading
   useEffect(() => {
     if (productId) {
       dispatch.products.fetchSingle(productId)
     }
   }, [productId])
+
+  useEffect(() => {
+    dispatch.tags.fetchIfEmpty()
+  }, [])
 
   if (fetching && !initialized) {
     return (
@@ -66,17 +67,15 @@ export const ProductPage: React.FC = () => {
               to={`/products/${product.id}/details`}
               match={`/products/${product.id}/details`}
               icon={<Icon platform={product.platform?.id} platformIcon size="lg" color="grayDark" />}
-              title={
-                <Stack direction="row" alignItems="center" spacing={1} sx={{ marginRight: 1 }}>
-                  <Title>{product.name}</Title>
-                  <ProductStatusChip status={product.status} />
-                </Stack>
-              }
+              title={<Title>{product.name}</Title>}
             />
             <Stack flexWrap="wrap" flexDirection="row" marginLeft={9.5} marginRight={3}>
-              <Typography variant="caption" color="grayDarker.main" gutterBottom>
+              <Typography variant="caption" color="grayDarker.main" gutterBottom sx={{ width: '100%' }}>
                 {product.platform?.name || `Platform ${product.platform?.id}`}
               </Typography>
+            </Stack>
+            <Stack flexWrap="wrap" flexDirection="row" marginLeft={9.5} marginRight={3}>
+              <ProductTagEditor product={product} />
             </Stack>
           </List>
         </>
@@ -84,20 +83,18 @@ export const ProductPage: React.FC = () => {
     >
       <Typography variant="subtitle1">
         <Title>Service</Title>
-        {!isLocked && (
-          <IconButton
-            icon="plus"
-            title="Add Service"
-            onClick={() => history.push(`/products/${product.id}/add`)}
-            size="md"
-          />
-        )}
+        <IconButton
+          icon="plus"
+          title="Add Service"
+          onClick={() => history.push(`/products/${product.id}/add`)}
+          size="md"
+        />
       </Typography>
 
       {product.services.length === 0 ? (
         <Gutters>
           <Notice severity="info" gutterTop fullWidth>
-            No services defined. Add at least one service before locking the product.
+            No services defined. Add at least one service to this product.
           </Notice>
         </Gutters>
       ) : (

--- a/frontend/src/pages/ProductsPage/ProductServiceAddPage.tsx
+++ b/frontend/src/pages/ProductsPage/ProductServiceAddPage.tsx
@@ -20,8 +20,6 @@ export const ProductServiceAddPage: React.FC = () => {
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState<string>()
 
-  const isLocked = product?.status === 'LOCKED'
-
   useEffect(() => {
     dispatch.applicationTypes.fetchAll()
   }, [])
@@ -33,22 +31,6 @@ export const ProductServiceAddPage: React.FC = () => {
           <Icon name="exclamation-triangle" size="xxl" color="warning" />
           <Typography variant="h2" gutterBottom sx={{ marginTop: 2 }}>
             Product not found
-          </Typography>
-        </Body>
-      </Container>
-    )
-  }
-
-  if (isLocked) {
-    return (
-      <Container gutterBottom>
-        <Body center>
-          <Icon name="lock" size="xxl" color="grayDark" />
-          <Typography variant="h2" gutterBottom sx={{ marginTop: 2 }}>
-            Product is locked
-          </Typography>
-          <Typography variant="body2" color="textSecondary" gutterBottom>
-            Services cannot be added to a locked product.
           </Typography>
         </Body>
       </Container>

--- a/frontend/src/pages/ProductsPage/ProductServiceDetailPage.tsx
+++ b/frontend/src/pages/ProductsPage/ProductServiceDetailPage.tsx
@@ -21,8 +21,6 @@ export const ProductServiceDetailPage: React.FC = () => {
   const product = products.find(p => p.id === productId)
   const service = product?.services.find(s => s.id === serviceId)
 
-  const isLocked = product?.status === 'LOCKED'
-
   const handleDelete = async () => {
     if (!product || !service) return
     const success = await dispatch.products.removeService({
@@ -67,20 +65,17 @@ export const ProductServiceDetailPage: React.FC = () => {
     <ProductServiceHeaderMenu
       product={product}
       service={service}
-      locked={isLocked}
       action={
-        !isLocked && (
-          <DeleteButton
-            title="Remove Service"
-            icon="trash"
-            onDelete={handleDelete}
-            warning={
-              <Notice severity="error" fullWidth>
-                Are you sure you want to remove the service <b>{service.name}</b>? This action cannot be undone.
-              </Notice>
-            }
-          />
-        )
+        <DeleteButton
+          title="Remove Service"
+          icon="trash"
+          onDelete={handleDelete}
+          warning={
+            <Notice severity="error" fullWidth>
+              Are you sure you want to remove the service <b>{service.name}</b>? This action cannot be undone.
+            </Notice>
+          }
+        />
       }
     >
       <Gutters>

--- a/frontend/src/pages/ProductsPage/ProductSettingsPage.tsx
+++ b/frontend/src/pages/ProductsPage/ProductSettingsPage.tsx
@@ -1,69 +1,41 @@
-import React, { useState } from 'react'
+import React, { useEffect } from 'react'
 import { useParams } from 'react-router-dom'
 import { useSelector } from 'react-redux'
-import { Typography, List } from '@mui/material'
-import { Icon } from '../../components/Icon'
+import { Typography } from '@mui/material'
 import { CopyCodeBlock } from '../../components/CopyCodeBlock'
-import { Body } from '../../components/Body'
 import { Gutters } from '../../components/Gutters'
 import { DataDisplay } from '../../components/DataDisplay'
 import { Container } from '../../components/Container'
 import { ProductHeaderMenu } from '../../components/ProductHeaderMenu'
 import { productDetailAttributes } from '../../components/ProductAttributes'
-import { ListItemSetting } from '../../components/ListItemSetting'
-import { dispatch } from '../../store'
 import { getProductModel } from '../../selectors/products'
+import { dispatch } from '../../store'
 
 export const ProductSettingsPage: React.FC = () => {
   const { productId } = useParams<{ productId: string }>()
   const { all: products } = useSelector(getProductModel)
   const product = products.find(p => p.id === productId)
-  const [updating, setUpdating] = useState(false)
 
-  const isLocked = product?.status === 'LOCKED'
   const registrationCommand = product?.registrationCommand
 
-  const handleLockToggle = async () => {
-    if (!product || isLocked) return
-    setUpdating(true)
-    await dispatch.products.updateSettings({
-      id: product.id,
-      input: { lock: true },
-    })
-    setUpdating(false)
-  }
+  useEffect(() => {
+    if (productId) dispatch.products.fetchSingle(productId)
+  }, [productId])
 
   if (!product) {
     return (
       <Container gutterBottom>
-        <Body center>
-          <Icon name="exclamation-triangle" size="xxl" color="warning" />
-          <Typography variant="h2" gutterBottom sx={{ marginTop: 2 }}>
-            Product not found
-          </Typography>
-        </Body>
+        <Typography variant="h2" gutterBottom sx={{ marginTop: 2 }}>
+          Product not found
+        </Typography>
       </Container>
     )
   }
 
   return (
     <ProductHeaderMenu product={product}>
-      <List>
-        <ListItemSetting
-          icon="lock"
-          label="Lock Product"
-          subLabel={
-            isLocked
-              ? 'This product is locked and cannot be unlocked.'
-              : 'Lock the product to enable bulk registration. Once locked, it cannot be unlocked.'
-          }
-          toggle={isLocked}
-          disabled={updating || isLocked}
-          onClick={handleLockToggle}
-        />
-      </List>
       <Gutters>
-        {isLocked && product.registrationCode && (
+        {product.registrationCode && (
           <>
             <Typography variant="subtitle2" color="textSecondary" gutterBottom>
               {registrationCommand ? 'Registration Command' : 'Registration Code'}

--- a/frontend/src/platforms/index.ts
+++ b/frontend/src/platforms/index.ts
@@ -25,6 +25,7 @@ export interface IPlatformOverrideProps {
   platform: IPlatform
   serviceTypes: number[]
   tags?: string[]
+  oneTimeUse?: boolean
 }
 
 class Platforms {

--- a/frontend/src/services/graphQLDeviceProducts.ts
+++ b/frontend/src/services/graphQLDeviceProducts.ts
@@ -30,6 +30,8 @@ export async function graphQLDeviceProducts(options?: {
                 status
                 registrationCode
                 registrationCommand
+                tags
+                source
                 created
                 updated
                 services {
@@ -64,6 +66,8 @@ export async function graphQLDeviceProduct(id: string, accountId?: string) {
                 status
                 registrationCode
                 registrationCommand
+                tags
+                source
                 created
                 updated
                 services {
@@ -179,5 +183,69 @@ export async function graphQLTransferDeviceProduct(productId: string, email: str
         transferDeviceProduct(productId: $productId, email: $email)
       }`,
     { productId, email }
+  )
+}
+
+export async function graphQLCreateDeviceProductFromRegistration(props: {
+  platform: number
+  tags?: string[]
+  services: { application: number; name?: string; port?: number; enabled?: boolean }[]
+  accountId?: string
+  name?: string
+}) {
+  const { accountId, ...input } = props
+  return await graphQLBasicRequest(
+    ` mutation CreateDeviceProductFromRegistration($accountId: String, $input: CreateDeviceProductFromRegistrationInput!) {
+        createDeviceProductFromRegistration(accountId: $accountId, input: $input) {
+          id
+          name
+          platform { id name }
+          status
+          tags
+          source
+          registrationCode
+          registrationCommand
+          created
+          updated
+          services {
+            id
+            name
+            type { id name }
+            port
+            enabled
+          }
+        }
+      }`,
+    { accountId, input }
+  )
+}
+
+export async function graphQLUpdateDeviceProduct(
+  id: string,
+  input: { name?: string; platform?: number; tags?: string[] }
+) {
+  return await graphQLBasicRequest(
+    ` mutation UpdateDeviceProduct($id: ID!, $input: UpdateDeviceProductInput!) {
+        updateDeviceProduct(id: $id, input: $input) {
+          id
+          name
+          platform { id name }
+          status
+          tags
+          source
+          registrationCode
+          registrationCommand
+          created
+          updated
+          services {
+            id
+            name
+            type { id name }
+            port
+            enabled
+          }
+        }
+      }`,
+    { id, input }
   )
 }

--- a/frontend/src/services/graphQLRequest.ts
+++ b/frontend/src/services/graphQLRequest.ts
@@ -159,13 +159,15 @@ export async function graphQLRegistration(props: {
   platform?: number
   services: IServiceRegistration[]
   accountId: string
+  oneTimeUse?: boolean
+  code?: string
 }) {
   return await graphQLBasicRequest(
-    ` query Registration($accountId: String, $name: String, $platform: Int, $tags: [String!], $services: [ServiceInput!]) {
+    ` query Registration($accountId: String, $name: String, $platform: Int, $tags: [String!], $services: [ServiceInput!], $oneTimeUse: Boolean, $code: String) {
         login {
           account(id: $accountId) {
-            registrationCode(name: $name, platform: $platform, tags: $tags, services: $services)
-            registrationCommand(name: $name, platform: $platform, tags: $tags, services: $services)
+            registrationCode(name: $name, platform: $platform, tags: $tags, services: $services, oneTimeUse: $oneTimeUse, code: $code)
+            registrationCommand(name: $name, platform: $platform, tags: $tags, services: $services, oneTimeUse: $oneTimeUse, code: $code)
           }
         }
       }`,

--- a/frontend/src/services/graphQLRequest.ts
+++ b/frontend/src/services/graphQLRequest.ts
@@ -161,17 +161,18 @@ export async function graphQLRegistration(props: {
   accountId: string
   oneTimeUse?: boolean
   code?: string
+  unique?: boolean
 }) {
   return await graphQLBasicRequest(
-    ` query Registration($accountId: String, $name: String, $platform: Int, $tags: [String!], $services: [ServiceInput!], $oneTimeUse: Boolean, $code: String) {
+    ` query Registration($accountId: String, $name: String, $platform: Int, $tags: [String!], $services: [ServiceInput!], $oneTimeUse: Boolean, $code: String, $unique: Boolean) {
         login {
           account(id: $accountId) {
-            registrationCode(name: $name, platform: $platform, tags: $tags, services: $services, oneTimeUse: $oneTimeUse, code: $code)
-            registrationCommand(name: $name, platform: $platform, tags: $tags, services: $services, oneTimeUse: $oneTimeUse, code: $code)
+            registrationCode(name: $name, platform: $platform, tags: $tags, services: $services, oneTimeUse: $oneTimeUse, code: $code, unique: $unique)
+            registrationCommand(name: $name, platform: $platform, tags: $tags, services: $services, oneTimeUse: $oneTimeUse, code: $code, unique: $unique)
           }
         }
       }`,
-    props
+    { ...props, unique: props.unique ?? true }
   )
 }
 


### PR DESCRIPTION
Update existing registration codes in place when options change, keep the command visible during updates, and add a chip toggle for one-time use on the platform add page.

This also retires the product **lock** concept in favor of freely editable products, and adds product tagging plus a "create product from registration" flow.

### Add Device / Platform page

- Added a clickable **MULTI USE / ONE-TIME USE** chip toggle below the tags editor. Defaults to multi-use; toggling controls whether the generated registration code is reusable or expires after a single registration.
- Added a **MAKE PRODUCT** button that creates a reusable device product from the current platform, tags, and selected services, then navigates to the new product's detail page. Disabled while creating or when no services are selected.
- The one-time-use setting is threaded through to the displayed registration code/command and platform overrides (e.g. Rent-a-Node).

### Registration code behavior

- Registration codes are now updated **in place** when tags/services change instead of being cleared and regenerated. The session code is reused and only reset when the account or platform changes, so the command stays visible during edits.
- Redux state is only written when the code/command actually changes, avoiding unnecessary re-renders.
- `createRegistration` now returns `{ registrationCode, registrationCommand }`; callers updated accordingly.

### Products — lock concept removed

- Removed the product **Lock** setting and the NEW/LOCKED status entirely. Products are now always editable.
- Registration command/code on the product settings page now shows unconditionally (no longer gated on the product being locked).
- Removed the product **Status** chip/column from product lists, detail views, and the product title.
- "Add Service" is always available; removed the "Product is locked" blocking screen on the service add page.
- "Remove Service" is no longer hidden on locked products.
- Added an inline **product tag editor** (`ProductTagEditor`) on the product page so tags can be added/removed directly.
- Updated empty-state copy: "Add at least one service before locking the product" → "Add at least one service to this product."

### API / models

- Added `oneTimeUse`, `code`, and `unique` parameters to the registration GraphQL query.
- Added `createDeviceProductFromRegistration` and `updateDeviceProduct` mutations; `IDeviceProduct` now carries `tags` and `source`.
- Replaced `updateSettings` (lock) with `updateProduct` (name/platform/tags) and `createFromRegistration`.
