### PR TITLE
feat(devices): gate bulk transfer behind paid plan

### DIFF
--- a/frontend/src/pages/DeviceTransferPage/DeviceBulkTransferPage.tsx
+++ b/frontend/src/pages/DeviceTransferPage/DeviceBulkTransferPage.tsx
@@ -4,7 +4,11 @@ import { Dispatch, State } from '../../store'
 import { Typography, Button } from '@mui/material'
 import { TransferForm } from './TransferForm'
 import { getAllDevices } from '../../selectors/devices'
-import { Redirect, useHistory } from 'react-router-dom'
+import { isPersonal } from '../../models/plans'
+import { Redirect, Link, useHistory } from 'react-router-dom'
+import { Container } from '../../components/Container'
+import { Gutters } from '../../components/Gutters'
+import { BillingUI } from '../../components/BillingUI'
 import { Notice } from '../../components/Notice'
 import { Icon } from '../../components/Icon'
 
@@ -16,6 +20,7 @@ export const DeviceBulkTransferPage: React.FC = () => {
   }))
   // Resolve against the same pool as the transferSelected thunk (selectDevice → getAllDevices)
   const allDevices = useSelector(getAllDevices)
+  const paidPlan = useSelector((state: State) => !isPersonal(state))
   const history = useHistory()
   const { devices } = useDispatch<Dispatch>()
 
@@ -31,6 +36,28 @@ export const DeviceBulkTransferPage: React.FC = () => {
   }
 
   if (!count) return <Redirect to="/devices" />
+
+  if (!paidPlan)
+    return (
+      <Container gutterBottom header={<Typography variant="h1">Transfer Devices</Typography>}>
+        <Gutters>
+          <Notice
+            severity="info"
+            fullWidth
+            button={
+              <BillingUI>
+                <Button to="/account/plans" variant="contained" color="primary" size="small" component={Link}>
+                  Upgrade
+                </Button>
+              </BillingUI>
+            }
+          >
+            Bulk device transfer requires a paid plan.
+            <em>Upgrade to transfer multiple devices at once. You can still transfer devices one at a time.</em>
+          </Notice>
+        </Gutters>
+      </Container>
+    )
 
   return (
     <TransferForm


### PR DESCRIPTION
## Summary

Puts the **bulk device transfer** feature (added in #1123) behind the paid-plan paywall. Free (Personal plan) accounts see an upgrade prompt on the Transfer Devices page instead of the transfer form — matching how the logs page prompts for an upgrade. Single-device transfer is unchanged and remains available on all plans.

## Behavior

- **Paid plans** (`!isPersonal`): full bulk transfer form, as before.
- **Free / Personal plan**: the page shows an info `Notice` — "Bulk device transfer requires a paid plan. Upgrade to transfer multiple devices at once. You can still transfer devices one at a time." — with an **Upgrade** button (wrapped in `BillingUI`, hidden on Android) linking to `/account/plans`.

The action-bar transfer button stays visible for free users so the feature is discoverable; the paywall is presented on the page itself.

## Implementation

- `DeviceBulkTransferPage.tsx` — added `paidPlan = !isPersonal(state)`; when false, render the upgrade `Notice` in place of the form. Reuses the existing `Notice` + `BillingUI` + Upgrade-button pattern from `EventList` (logs).

## Notes

- UI-level gate, consistent with the app's other paywalls (logs, etc.); the GraphQL `transfer` mutation is authorization-based and not plan-gated server-side.
- Free vs paid uses the existing `isPersonal` helper (Personal plan = free) — the same check `ProfilePage` uses for `paidPlan`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
