### PR TITLE
feat(devices): move transfer/delete into overflow menu on devices action bar

### DIFF
--- a/frontend/src/components/DevicesActionBar.tsx
+++ b/frontend/src/components/DevicesActionBar.tsx
@@ -1,19 +1,19 @@
 import React from 'react'
 import { makeStyles } from '@mui/styles'
 import { MOBILE_WIDTH } from '../constants'
-import { useMediaQuery, Box, Divider, Typography, InputLabel } from '@mui/material'
+import { Box, Divider, Typography, InputLabel } from '@mui/material'
 import { State, Dispatch } from '../store'
 import { useSelector, useDispatch } from 'react-redux'
 import { selectLimitsLookup, selectPermissions } from '../selectors/organizations'
 import { selectActiveAccountId } from '../selectors/accounts'
 import { getSelectedTags } from '../helpers/selectedHelper'
+import { useContainerWidth } from '../hooks/useContainerWidth'
 import { canEditTags } from '../models/tags'
-import { ConfirmIconButton } from '../buttons/ConfirmIconButton'
 import { IconButton } from '../buttons/IconButton'
 import { useHistory } from 'react-router-dom'
 import { selectTags } from '../selectors/tags'
+import { DevicesActionMenu } from './DevicesActionMenu'
 import { TagEditor } from './TagEditor'
-import { Notice } from './Notice'
 import { Title } from './Title'
 import { Icon } from './Icon'
 import { spacing, radius } from '../styling'
@@ -27,11 +27,10 @@ export const DevicesActionBar: React.FC<Props> = ({ devices }) => {
   const selected = useSelector((state: State) => state.ui.selected)
   const adding = useSelector((state: State) => state.tags.adding)
   const removing = useSelector((state: State) => state.tags.removing)
-  const destroying = useSelector((state: State) => state.ui.destroying)
-  const transferring = useSelector((state: State) => state.ui.transferring)
   const permissions = useSelector(selectPermissions)
   const canEdit = useSelector((state: State) => canEditTags(state, accountId))
-  const mobile = useMediaQuery(`(max-width:${MOBILE_WIDTH}px)`)
+  const { containerRef, containerWidth } = useContainerWidth()
+  const mobile = containerWidth < MOBILE_WIDTH
   const dispatch = useDispatch<Dispatch>()
   const history = useHistory()
   const css = useStyles()
@@ -39,13 +38,24 @@ export const DevicesActionBar: React.FC<Props> = ({ devices }) => {
   const onCreate = async tag => await dispatch.tags.create({ tag, accountId })
 
   return (
-    <Box className={css.actions}>
-      <Title>
+    <Box className={css.actions} ref={containerRef}>
+      <IconButton
+        icon="times"
+        title="Clear selection"
+        color="alwaysWhite"
+        placement="bottom"
+        onClick={() => {
+          dispatch.ui.set({ selected: [], selectionAnchor: undefined })
+          history.push('/devices')
+        }}
+      />
+      <Title sx={{ flexGrow: 0 }}>
         <Typography variant="subtitle1">
           {selected.length}&nbsp;
           {mobile ? <Icon name="check" inline /> : 'Selected'}
         </Typography>
       </Title>
+      <Box sx={{ flexGrow: 1 }} />
       {feature.tagging && canEdit && (
         <>
           {mobile || <InputLabel shrink>tags</InputLabel>}
@@ -106,51 +116,7 @@ export const DevicesActionBar: React.FC<Props> = ({ devices }) => {
           <Divider orientation="vertical" color="white" />
         </>
       )}
-      <IconButton
-        icon="arrow-turn-down-right"
-        title="Transfer selected"
-        color="alwaysWhite"
-        placement="bottom"
-        disabled={!selected.length}
-        loading={transferring}
-        to="/devices/transfer"
-      />
-      <ConfirmIconButton
-        icon="trash"
-        title="Delete selected"
-        color="alwaysWhite"
-        placement="bottom"
-        disabled={!selected.length}
-        loading={destroying}
-        onClick={async () => {
-          await dispatch.devices.destroySelected(selected)
-          history.push('/devices')
-        }}
-        confirmProps={{
-          title: 'Confirm Device Deletion',
-          color: 'error',
-          action: `Delete ${selected.length} device${selected.length === 1 ? '' : 's'}`,
-          children: (
-            <>
-              <Notice severity="error" gutterBottom fullWidth>
-                Deletion is irreversible and may require device access for recovery.
-              </Notice>
-              <Typography variant="body2">Uninstall the Remote.It agent before deletion for best results.</Typography>
-            </>
-          ),
-        }}
-        confirm
-      />
-      <IconButton
-        icon="times"
-        title="Clear selection"
-        color="alwaysWhite"
-        placement="bottom"
-        onClick={() => {
-          dispatch.ui.set({ selected: [], selectionAnchor: undefined })
-          history.push('/devices')
-        }}
-      />
+      <DevicesActionMenu />
     </Box>
   )
 }
@@ -168,11 +134,13 @@ const useStyles = makeStyles(({ palette }) => ({
     marginLeft: spacing.sm,
     marginRight: spacing.sm,
     marginBottom: spacing.xs,
+    paddingLeft: spacing.sm,
     paddingRight: spacing.sm,
     zIndex: 10,
     '& .MuiTypography-subtitle1': {
       marginTop: spacing.xs,
       marginBottom: spacing.xs,
+      paddingLeft: spacing.sm,
       fontWeight: 800,
       color: palette.alwaysWhite.main,
     },

--- a/frontend/src/components/DevicesActionMenu.tsx
+++ b/frontend/src/components/DevicesActionMenu.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react'
+import { State, Dispatch } from '../store'
+import { useSelector, useDispatch } from 'react-redux'
+import { Link, useHistory } from 'react-router-dom'
+import { Menu, MenuItem, ListSubheader, ListItemIcon, ListItemText, Typography } from '@mui/material'
+import { IconButton } from '../buttons/IconButton'
+import { Confirm } from './Confirm'
+import { Notice } from './Notice'
+import { Icon } from './Icon'
+
+export const DevicesActionMenu: React.FC = () => {
+  const selected = useSelector((state: State) => state.ui.selected)
+  const dispatch = useDispatch<Dispatch>()
+  const history = useHistory()
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
+  const [confirm, setConfirm] = useState<boolean>(false)
+
+  const handleClose = () => setAnchorEl(null)
+  const count = `${selected.length} device${selected.length === 1 ? '' : 's'}`
+
+  return (
+    <>
+      <IconButton
+        icon="ellipsis-v"
+        title="More"
+        color="alwaysWhite"
+        placement="bottom"
+        disabled={!selected.length}
+        onClick={e => setAnchorEl(e.currentTarget as HTMLButtonElement)}
+      />
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        disableScrollLock
+        autoFocus={false}
+        elevation={2}
+      >
+        <ListSubheader sx={{ backgroundColor: 'transparent' }}>{count} selected</ListSubheader>
+        <MenuItem dense to="/devices/transfer" component={Link} onClick={handleClose}>
+          <ListItemIcon>
+            <Icon name="arrow-turn-down-right" size="md" />
+          </ListItemIcon>
+          <ListItemText primary="Transfer" />
+        </MenuItem>
+        <MenuItem
+          dense
+          onClick={() => {
+            handleClose()
+            setConfirm(true)
+          }}
+        >
+          <ListItemIcon>
+            <Icon name="trash" size="md" />
+          </ListItemIcon>
+          <ListItemText primary="Delete" />
+        </MenuItem>
+      </Menu>
+      <Confirm
+        open={confirm}
+        title="Confirm Device Deletion"
+        action={`Delete ${count}`}
+        color="error"
+        onConfirm={async () => {
+          setConfirm(false)
+          await dispatch.devices.destroySelected(selected)
+          history.push('/devices')
+        }}
+        onDeny={() => setConfirm(false)}
+      >
+        <Notice severity="error" gutterBottom fullWidth>
+          Deletion is irreversible and may require device access for recovery.
+        </Notice>
+        <Typography variant="body2">Uninstall the Remote.It agent before deletion for best results.</Typography>
+      </Confirm>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary

Reworks the multi-select **devices action bar** to match the overflow-menu pattern used on the device detail page, and fixes its spacing/responsive behavior.

- **Transfer & Delete moved into a "⋮" overflow menu** (new `DevicesActionMenu`), mirroring `DeviceOptionMenu`. The menu has a `N devices selected` subheader (transparent background) followed by **Transfer** and **Delete** items. Delete opens the existing `Confirm` dialog — the menu item reads "Delete" while the destructive confirm button keeps the explicit "Delete N devices" wording.
- **Clear-selection ✕ moved to the far left**, next to the "N Selected" count (contextual-action-bar convention), separated from the act-on-selection controls on the right.
- **Spacing fixes:** symmetric left/right edge padding on the bar; count no longer balloons (`Title` pinned to `flexGrow: 0` with an explicit spacer pushing the tag/script/⋮ cluster right); count's left padding reduced from the theme's `spacing.xl` (36px) to `spacing.sm` (12px), scoped to the bar.
- **Responsive fix:** the bar now compacts based on its **own column width** via `useContainerWidth` (ResizeObserver) instead of the window-width media query. This fixes clipping when the `/devices/transfer` `DynamicPanel` squeezes the device list into a narrow column while the window stays wide.

## Testing

- `tsc --noEmit` passes.
- Flex spacing verified with a measured DOM replica (symmetric 12px edges; count 12px gutter).
- UI verified visually by the author in a logged-in instance.