### PR TITLE
fix(contacts): scope share/transfer email suggestions to the active org

### DIFF
--- a/frontend/src/components/OrganizationGuestList.tsx
+++ b/frontend/src/components/OrganizationGuestList.tsx
@@ -1,10 +1,8 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import { useStyles } from './SharedUsersPaginatedList'
-import { Dispatch } from '../store'
-import { useSelector, useDispatch } from 'react-redux'
 import { List, ListSubheader, ListItemSecondaryAction, Box, Chip } from '@mui/material'
 import { ListItemLocation } from './ListItemLocation'
-import { selectOrganization } from '../selectors/organizations'
+import { useGuests } from '../hooks/useGuests'
 import { LoadingMessage } from './LoadingMessage'
 import { Pagination } from '@mui/lab'
 import { Gutters } from './Gutters'
@@ -13,17 +11,12 @@ import { Icon } from './Icon'
 
 export const OrganizationGuestList: React.FC = () => {
   const css = useStyles()
-  const dispatch = useDispatch<Dispatch>()
   const [page, setPage] = useState<number>(1)
-  const { guests, guestsLoaded } = useSelector(selectOrganization)
+  const { guests, guestsLoaded } = useGuests()
   const perPage = 20
   const pageCount = Math.ceil(guests.length / perPage)
   const start = (page - 1) * perPage
   const pageGuests = [...guests].sort(alphaEmailSort).slice(start, start + perPage)
-
-  useEffect(() => {
-    if (!guestsLoaded) dispatch.organization.fetchGuests()
-  }, [guests])
 
   if (!guestsLoaded) return <LoadingMessage />
 

--- a/frontend/src/hooks/useGuests.ts
+++ b/frontend/src/hooks/useGuests.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+import { Dispatch } from '../store'
+import { selectOrganization } from '../selectors/organizations'
+
+// Lazily loads the active org's guests (they are not part of the normal
+// organization.fetch query) and returns them along with the loaded flag. Safe
+// to call from any page that needs guest data — the fetch only fires once per
+// account.
+export function useGuests(): { guests: IGuest[]; guestsLoaded: boolean } {
+  const dispatch = useDispatch<Dispatch>()
+  const { guests, guestsLoaded } = useSelector(selectOrganization)
+
+  useEffect(() => {
+    if (!guestsLoaded) dispatch.organization.fetchGuests()
+  }, [guests])
+
+  return { guests, guestsLoaded }
+}

--- a/frontend/src/pages/DeviceTransferPage/DeviceBulkTransferPage.tsx
+++ b/frontend/src/pages/DeviceTransferPage/DeviceBulkTransferPage.tsx
@@ -4,16 +4,15 @@ import { Dispatch, State } from '../../store'
 import { Typography, Button } from '@mui/material'
 import { TransferForm } from './TransferForm'
 import { getAllDevices } from '../../selectors/devices'
+import { selectContacts } from '../../selectors/contacts'
 import { Redirect, useHistory } from 'react-router-dom'
 import { Notice } from '../../components/Notice'
 import { Icon } from '../../components/Icon'
 
 export const DeviceBulkTransferPage: React.FC = () => {
-  const { contacts = [], transferring, selected } = useSelector((state: State) => ({
-    contacts: state.contacts.all,
-    transferring: state.ui.transferring,
-    selected: state.ui.selected,
-  }))
+  const contacts = useSelector(selectContacts)
+  const transferring = useSelector((state: State) => state.ui.transferring)
+  const selected = useSelector((state: State) => state.ui.selected)
   // Resolve against the same pool as the transferSelected thunk (selectDevice → getAllDevices)
   const allDevices = useSelector(getAllDevices)
   const history = useHistory()

--- a/frontend/src/pages/DeviceTransferPage/DeviceBulkTransferPage.tsx
+++ b/frontend/src/pages/DeviceTransferPage/DeviceBulkTransferPage.tsx
@@ -5,6 +5,7 @@ import { Typography, Button } from '@mui/material'
 import { TransferForm } from './TransferForm'
 import { getAllDevices } from '../../selectors/devices'
 import { selectContacts } from '../../selectors/contacts'
+import { useGuests } from '../../hooks/useGuests'
 import { Redirect, useHistory } from 'react-router-dom'
 import { Notice } from '../../components/Notice'
 import { Icon } from '../../components/Icon'
@@ -13,6 +14,7 @@ export const DeviceBulkTransferPage: React.FC = () => {
   const contacts = useSelector(selectContacts)
   const transferring = useSelector((state: State) => state.ui.transferring)
   const selected = useSelector((state: State) => state.ui.selected)
+  useGuests()
   // Resolve against the same pool as the transferSelected thunk (selectDevice → getAllDevices)
   const allDevices = useSelector(getAllDevices)
   const history = useHistory()

--- a/frontend/src/pages/DeviceTransferPage/DeviceTransferPage.tsx
+++ b/frontend/src/pages/DeviceTransferPage/DeviceTransferPage.tsx
@@ -3,15 +3,14 @@ import { useDispatch, useSelector } from 'react-redux'
 import { Dispatch, State } from '../../store'
 import { Typography } from '@mui/material'
 import { TransferForm } from './TransferForm'
+import { selectContacts } from '../../selectors/contacts'
 import { Notice } from '../../components/Notice'
 
 type Props = { device?: IDevice }
 
 export const DeviceTransferPage: React.FC<Props> = ({ device }) => {
-  const { contacts = [], transferring } = useSelector((state: State) => ({
-    contacts: state.contacts.all,
-    transferring: state.ui.transferring,
-  }))
+  const contacts = useSelector(selectContacts)
+  const transferring = useSelector((state: State) => state.ui.transferring)
   const { devices } = useDispatch<Dispatch>()
 
   if (!device) return null

--- a/frontend/src/pages/DeviceTransferPage/DeviceTransferPage.tsx
+++ b/frontend/src/pages/DeviceTransferPage/DeviceTransferPage.tsx
@@ -4,6 +4,7 @@ import { Dispatch, State } from '../../store'
 import { Typography } from '@mui/material'
 import { TransferForm } from './TransferForm'
 import { selectContacts } from '../../selectors/contacts'
+import { useGuests } from '../../hooks/useGuests'
 import { Notice } from '../../components/Notice'
 
 type Props = { device?: IDevice }
@@ -12,6 +13,7 @@ export const DeviceTransferPage: React.FC<Props> = ({ device }) => {
   const contacts = useSelector(selectContacts)
   const transferring = useSelector((state: State) => state.ui.transferring)
   const { devices } = useDispatch<Dispatch>()
+  useGuests()
 
   if (!device) return null
 

--- a/frontend/src/pages/SharePage/SharePage.tsx
+++ b/frontend/src/pages/SharePage/SharePage.tsx
@@ -7,6 +7,7 @@ import { useParams, useHistory } from 'react-router-dom'
 import { Typography, IconButton, Tooltip, CircularProgress } from '@mui/material'
 import { spacing, fontSizes } from '../../styling'
 import { selectOrganization } from '../../selectors/organizations'
+import { selectContacts } from '../../selectors/contacts'
 import { ContactSelector } from '../../components/ContactSelector'
 import { SharingForm } from '../../components/SharingForm'
 import { getAccess } from '../../helpers/userHelper'
@@ -20,7 +21,7 @@ export const SharePage: React.FC = () => {
   const dispatch = useDispatch<Dispatch>()
   const { device, service } = useContext(DeviceContext)
   const { userID = '' } = useParams<{ userID?: string }>()
-  const contacts = useSelector((state: State) => state.contacts.all)
+  const contacts = useSelector(selectContacts)
   const guests = device ? device.access : (useSelector(selectOrganization).guests as IUserRef[])
   const deleting = useSelector((state: State) => state.shares.deleting)
   const users = useSelector((state: State) => state.shares.currentDevice?.users || [])

--- a/frontend/src/pages/SharePage/SharePage.tsx
+++ b/frontend/src/pages/SharePage/SharePage.tsx
@@ -6,8 +6,8 @@ import { Dispatch, State } from '../../store'
 import { useParams, useHistory } from 'react-router-dom'
 import { Typography, IconButton, Tooltip, CircularProgress } from '@mui/material'
 import { spacing, fontSizes } from '../../styling'
-import { selectOrganization } from '../../selectors/organizations'
 import { selectContacts } from '../../selectors/contacts'
+import { useGuests } from '../../hooks/useGuests'
 import { ContactSelector } from '../../components/ContactSelector'
 import { SharingForm } from '../../components/SharingForm'
 import { getAccess } from '../../helpers/userHelper'
@@ -22,7 +22,8 @@ export const SharePage: React.FC = () => {
   const { device, service } = useContext(DeviceContext)
   const { userID = '' } = useParams<{ userID?: string }>()
   const contacts = useSelector(selectContacts)
-  const guests = device ? device.access : (useSelector(selectOrganization).guests as IUserRef[])
+  const { guests: orgGuests } = useGuests()
+  const guests = device ? device.access : (orgGuests as IUserRef[])
   const deleting = useSelector((state: State) => state.shares.deleting)
   const users = useSelector((state: State) => state.shares.currentDevice?.users || [])
   const guest = guests.find(g => g.id === userID)

--- a/frontend/src/selectors/contacts.ts
+++ b/frontend/src/selectors/contacts.ts
@@ -1,0 +1,29 @@
+import { createSelector } from 'reselect'
+import { State } from '../store'
+import { selectOrganization } from './organizations'
+import { isUserAccount } from './accounts'
+
+const getContacts = (state: State) => state.contacts.all
+
+// Email suggestions for the share / transfer dropdowns.
+// Sourced from the ACTIVE org's members + guests (scoped via selectOrganization),
+// plus the signed-in user's personal contacts only when viewing their own account.
+export const selectContacts = createSelector(
+  [selectOrganization, isUserAccount, getContacts],
+  (organization, ownAccount, contacts): IUserRef[] => {
+    const orgRefs: IUserRef[] = [
+      ...organization.members.map(m => m.user),
+      ...organization.guests.map(g => ({ id: g.id, email: g.email })),
+    ]
+    const combined = ownAccount ? [...orgRefs, ...contacts] : orgRefs
+    const seen = new Set<string>()
+    return combined
+      .filter(c => {
+        const key = c.email?.trim().toLowerCase()
+        if (!key || seen.has(key)) return false
+        seen.add(key)
+        return true
+      })
+      .sort((a, b) => a.email.localeCompare(b.email, undefined, { sensitivity: 'base' }))
+  }
+)


### PR DESCRIPTION
## Problem

The email autocomplete in the **transfer device** and **share device** dropdowns was populated solely from `state.contacts.all`, which comes from the GraphQL `login { contacts }` query — the *signed-in user's* personal contacts. This list is never scoped to the active account.

So when an admin switches into another org to transfer/share a device, the dropdown kept suggesting their personal contacts instead of the org's members and guests. Every other org-scoped view already keys off the active account via `selectOrganization` / `selectActiveAccountId`.

## Fix

New `selectContacts` selector that sources suggestions from the **active org's** members + guests (already scoped through `selectOrganization`), plus the user's personal contacts only when viewing their own account. Results are deduped by email and sorted alphabetically (case-insensitive) for a predictable dropdown.

Wired into all three call sites that previously read `state.contacts.all`:
- `DeviceTransferPage`
- `DeviceBulkTransferPage`
- `SharePage` (add-share path)

`TransferForm` and `ContactSelector` are unchanged — they already accept `contacts: IUserRef[]`.

## Testing

- `tsc --noEmit` passes.
- Verified locally: on another org the dropdown now shows that org's members/guests; on your own account personal contacts still appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)