### PR TITLE
🚧 Remove macOS Electron system tray in favor of remoteit-tray

### DIFF
--- a/electron/src/ElectronApp.ts
+++ b/electron/src/ElectronApp.ts
@@ -341,18 +341,24 @@ export default class ElectronApp {
   }
 
   private createSystemTray() {
-    Logger.info('CREATE SYSTEM TRAY')
+    // On macOS the menu-bar tray is now provided by the standalone `remoteit-tray`
+    // app (cli-source), so it lives with the agent and survives this app quitting.
+    // Other platforms keep the Electron tray until remoteit-tray supports them.
+    if (environment.isMac) {
+      Logger.info('SYSTEM TRAY: macOS uses standalone remoteit-tray; skipping Electron tray')
+    } else {
+      Logger.info('CREATE SYSTEM TRAY')
+      this.tray = new electron.Tray(this.getIconPath())
+      new TrayMenu(this.tray)
+      if (environment.isWindows) {
+        electron.nativeTheme.on('updated', () => this.tray?.setImage(this.getIconPath()))
+      }
+    }
 
-    this.tray = new electron.Tray(this.getIconPath())
-    new TrayMenu(this.tray)
     const defaultMenu = Menu.getApplicationMenu()
     const items = defaultMenu?.items.filter(item => item.role !== 'help')
     const menu = Menu.buildFromTemplate(items || [])
     Menu.setApplicationMenu(menu)
-
-    if (environment.isWindows) {
-      electron.nativeTheme.on('updated', () => this.tray?.setImage(this.getIconPath()))
-    }
   }
 
   private getIconPath() {
@@ -375,7 +381,9 @@ export default class ElectronApp {
   }
 
   private openWindow = (location?: string, openDevTools?: boolean) => {
-    if (!this.window || !this.tray) return
+    // No longer gate on this.tray: on macOS the Electron tray is not created
+    // (see createSystemTray). The window is driven by activate/open-url handlers.
+    if (!this.window) return
 
     if (!this.window.isVisible()) {
       if (this.app.dock) this.app.dock.show()


### PR DESCRIPTION
Draft — depends on remoteit-tray shipping. See ⚠️ below before merging.

## What

On macOS, stop creating the Electron `Tray` + `TrayMenu`. The menu-bar tray is now provided by the standalone **remoteit-tray** app (in `cli-source`), so it lives with the agent and survives this app being quit — the original motivation.

- `createSystemTray()` skips the tray on macOS (`environment.isMac`); the application menu setup is unchanged. **Windows/Linux keep the Electron tray** until remoteit-tray supports them (Phase 3).
- `openWindow()` no longer gates on `this.tray` (it was only a guard, not a positioning anchor). The window is driven by the existing `activate` / `open-url` handlers, so the standalone tray's "Open remote.it Desktop" item works.
- `TrayMenu.ts` is retained (still used on Windows/Linux).

Companion CLI PR: remoteit/cli-source#426

## ⚠️ Merge ordering — do not ship before remoteit-tray is bundled

remoteit-tray is not yet bundled or auto-installed by this app. If this merges/ships as-is, **macOS users would lose their tray entirely** until they manually install remoteit-tray. This PR should land only alongside (or after) the follow-up that:

1. bundles `remoteit-tray.app` in the desktop app's resources, and
2. installs/launches it on first run (`remoteit-tray install`),

plus codesigning/notarization of the bundled binary. Kept as a draft until then.

## Typecheck
`tsc -p electron/tsconfig.json --noEmit` clean.