### PR TITLE
fix(auth): verify session before completing two-factor account recovery

### DIFF
--- a/frontend/src/cognito/auth.ts
+++ b/frontend/src/cognito/auth.ts
@@ -343,10 +343,12 @@ export class AuthService {
       // Update the local copy of the Cognito user
       this.cognitoUser = newUser
 
-      // If only a the email verification code was provided,
-      // we assume that the user does not have two-factor setup
-      // and thus does not need the secondary challenge.
-      // if (recoveryCode) {
+      // A rejected email code leaves the EMAIL_CODE challenge pending. Stop here
+      // so the recovery code below isn't consumed as another email code attempt.
+      if (newUser.challengeName === 'CUSTOM_CHALLENGE' && newUser.challengeParam?.challengeType === 'EMAIL_CODE') {
+        return { error: new Error('Email verification code is invalid, please double check and try again!') }
+      }
+
       newUser = await this.cognitoAuth.sendCustomChallengeAnswer(this.cognitoUser, recoveryCode)
 
       // Update the local copy of the Cognito user
@@ -357,6 +359,12 @@ export class AuthService {
 
     if (this.cognitoUser.challengeName === 'CUSTOM_CHALLENGE') {
       return { error: new Error('Backup code is invalid, please double check and try again!') }
+    }
+
+    // The custom auth flow can end without issuing tokens. Treat that as a
+    // failure so the user isn't redirected into an unauthenticated app.
+    if (!this.cognitoUser.signInUserSession) {
+      return { error: new Error('Account recovery did not complete, please try again or contact support.') }
     }
 
     // Now get the Remote.It specific account information and

--- a/frontend/src/cognito/components/AccountRecovery/AccountRecovery.tsx
+++ b/frontend/src/cognito/components/AccountRecovery/AccountRecovery.tsx
@@ -4,17 +4,19 @@ import { useTranslation } from 'react-i18next'
 import { AuthLayout } from '../AuthLayout'
 import { Notice } from '../../../components/Notice'
 import { Icon } from '../../../components/Icon'
-import { VerifyRecoveryCodeFunc, SignInFunc } from '../../types'
+import { VerifyRecoveryCodeFunc, SignInFunc, SignInSuccessFunc } from '../../types'
 
 export type AccountRecoveryProps = {
   onVerifyRecoveryCode: VerifyRecoveryCodeFunc
   onSignIn: SignInFunc
+  onSignInSuccess: SignInSuccessFunc
   email: string
   fullWidth?: boolean
 }
 
 export function AccountRecovery({
   onSignIn,
+  onSignInSuccess,
   onVerifyRecoveryCode,
   email,
   fullWidth,
@@ -64,8 +66,10 @@ export function AccountRecovery({
       const result = await onVerifyRecoveryCode(emailVerificationCode, recoveryCode)
       if (result.error) {
         setError(result.error.message)
+      } else if (result.cognitoUser) {
+        onSignInSuccess(result.cognitoUser)
       } else {
-        window.location.href = '/#devices'
+        setError('Account recovery did not complete, please try again or contact support.')
       }
     } catch (e) {
       setError(t(`pages.auth-mfa.errors.${e.code}`))

--- a/frontend/src/cognito/components/Auth/Auth.tsx
+++ b/frontend/src/cognito/components/Auth/Auth.tsx
@@ -166,6 +166,7 @@ function Routes({
               email={email}
               fullWidth={fullWidth}
               onSignIn={handleSignIn2}
+              onSignInSuccess={onSignInSuccess}
               onVerifyRecoveryCode={onVerifyRecoveryCode}
             />
           )}


### PR DESCRIPTION
## Summary

Fixes the two-factor account recovery loop reported by a locked-out user: completing recovery (email code + recovery code) appeared to succeed but bounced them back to the sign-in screen, where the account still demanded SMS codes that never arrive.

- **`verifyRecoveryCode` now confirms Cognito actually issued a session** (`signInUserSession`) before declaring success. Previously any custom-auth flow that ended without tokens was treated as success, triggering a redirect into an unauthenticated app — the reported loop.
- **A rejected email verification code now stops the flow with a clear error.** Previously the recovery code was blindly submitted as the next challenge answer, so a bad email code silently consumed the recovery code as another email-code attempt and burned Cognito's limited retries.
- **Successful recovery now signs in through `onSignInSuccess`** (same path as the SMS/TOTP flows) instead of a raw `window.location.href = '/#devices'` reload — which was fragile and the wrong format for `HashRouter` (`#devices` vs `#/devices`).

## Not covered here (backend)

- If the recovery lambda ends the flow without issuing tokens or without clearing the SMS MFA preference, users will now see an explicit error instead of a silent bounce — but the lambda side still needs verification.
- SMS delivery failures (SNS logs / spend limit / Canadian origination for +1-705 numbers) are outside this repo.

## Test plan

- `npm run typecheck` passes
- Recovery flow: wrong email code → error shown, recovery code not consumed
- Recovery flow: valid codes → authenticated app renders (no reload), lands on /devices
- Recovery flow: flow ends without session → explicit error instead of redirect to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)