### PR TITLE
feat(platforms): add TOA platform type (1228)

### DIFF
--- a/frontend/src/platforms/index.ts
+++ b/frontend/src/platforms/index.ts
@@ -61,6 +61,7 @@ class Platforms {
     'remoteit',
     'this',
     'tinkerboard',
+    'toa',
     'ubiquiti',
     'ubuntu',
     'unknown',

--- a/frontend/src/platforms/toa/index.tsx
+++ b/frontend/src/platforms/toa/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { platforms } from '..'
+
+const Component = ({ darkMode, ...props }) => {
+  const base = darkMode ? '#fff' : '#707372'
+  return (
+    <svg viewBox="0 0 256 256" version="1.1" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <title>TOA</title>
+      <polygon fill={base} points="96 256 0 256 96 160 96 256" />
+      <polygon fill={base} points="0 240 0 176 64 112 128 112 0 240" />
+      <polygon fill="#ff8200" points="0 160 0 64 96 64 0 160" />
+      <rect fill={base} x="0" width="256" height="16" />
+      <polygon fill={base} points="256 256 160 256 160 112 192 112 256 48 256 256" />
+    </svg>
+  )
+}
+
+platforms.register({
+  id: 'toa',
+  name: 'TOA',
+  component: Component,
+  types: { 1228: 'TOA' },
+})

--- a/frontend/src/services/graphQLDevice.ts
+++ b/frontend/src/services/graphQLDevice.ts
@@ -343,7 +343,7 @@ export function graphQLDeviceAdaptor({
       lastReported: d.lastReported && new Date(d.lastReported),
       externalAddress: d.endpoint?.externalAddress,
       internalAddress: d.endpoint?.internalAddress,
-      targetPlatform: d.platform, // || 1214,
+      targetPlatform: d.platform, // || 1214 to preview a new platform
       availability: d.endpoint?.availability,
       instability: d.endpoint?.instability,
       quality: d.endpoint?.quality,


### PR DESCRIPTION
Adds a new **TOA** platform (type `1228`) for a customer. It is not user-addable — modeled on `liverock` (inline SVG, no `installation` block), so it won't appear in the add-device platform picker.

## Changes
- **`frontend/src/platforms/toa/index.tsx`** — new platform. Inlines the TOA symbol as SVG and honors dark mode: the gray marks (`#707372`) flip to white (`#fff`) when `darkMode` is set; the orange (`#ff8200`) stays constant. This covers both logo variants from a single component, no asset files needed.
- **`frontend/src/platforms/index.ts`** — registers `'toa'` in the `installed` list.
- **`frontend/src/services/graphQLDevice.ts`** — clarified the preview comment on `targetPlatform`.

## Testing
Verified in the running Electron app by temporarily forcing `targetPlatform: 1228` — logo renders correctly in both light and dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)