### PR TITLE
fix: left-justify detail-page titles and fix products empty-state icon spacing

### DIFF
--- a/frontend/src/components/Avatar/Avatar.tsx
+++ b/frontend/src/components/Avatar/Avatar.tsx
@@ -55,7 +55,7 @@ export const Avatar: React.FC<Props> = React.memo(
             fontFamily: 'Roboto Mono',
             backgroundColor: labelLookup[color].color,
             border: `${border}px solid ${theme.palette.white.main}`,
-            marginRight: inline ? `${spacing.sm}px` : marginRight,
+            marginRight: inline ? `${spacing.sm}px` : marginRight ? `${marginRight}px` : undefined,
           })}
         >
           <div>{fallback}</div>

--- a/frontend/src/pages/ProductsPage/ProductsPage.tsx
+++ b/frontend/src/pages/ProductsPage/ProductsPage.tsx
@@ -57,41 +57,41 @@ export const ProductsPage: React.FC = () => {
         gutterBottom
         bodyProps={{ verticalOverflow: true, horizontalOverflow: true }}
       >
-      {fetching && !initialized ? (
-        <LoadingMessage message="Loading products..." />
-      ) : products.length === 0 ? (
-        <Body center>
-          <Icon name="box-open" size="xxl" color="grayLight" />
-          <Typography variant="h2" gutterBottom sx={{ marginTop: 2 }}>
-            No products
-          </Typography>
-          <Typography variant="body2" color="textSecondary" gutterBottom>
-            Products are used for bulk device registration and management.
-          </Typography>
-          <Button
-            variant="contained"
-            color="primary"
-            sx={{ marginTop: 2 }}
-            onClick={() => history.push('/products/add')}
-          >
-            <Icon name="plus" size="sm" inline />
-            Create your first product
-          </Button>
-        </Body>
-      ) : (
-        <ProductList
-          attributes={attributes}
-          required={required}
-          products={products}
-          columnWidths={columnWidths}
-          fetching={fetching}
-          select={select}
-          selected={selected}
-          activeProductId={productId}
-          onSelect={handleSelect}
-          onSelectAll={handleSelectAll}
-        />
-      )}
+        {fetching && !initialized ? (
+          <LoadingMessage message="Loading products..." />
+        ) : products.length === 0 ? (
+          <Body center>
+            <Icon name="box-open" size="xxl" color="grayLight" />
+            <Typography variant="h2" gutterBottom sx={{ marginTop: 2 }}>
+              No products
+            </Typography>
+            <Typography variant="body2" color="textSecondary" gutterBottom>
+              Products are used for bulk device registration and management.
+            </Typography>
+            <Button
+              variant="contained"
+              color="primary"
+              sx={{ marginTop: 2 }}
+              onClick={() => history.push('/products/add')}
+            >
+              <Icon name="plus" size="sm" inlineLeft />
+              Create your first product
+            </Button>
+          </Body>
+        ) : (
+          <ProductList
+            attributes={attributes}
+            required={required}
+            products={products}
+            columnWidths={columnWidths}
+            fetching={fetching}
+            select={select}
+            selected={selected}
+            activeProductId={productId}
+            onSelect={handleSelect}
+            onSelectAll={handleSelectAll}
+          />
+        )}
       </Container>
     </Box>
   )


### PR DESCRIPTION
## Summary

Two related UI alignment fixes.

### 1. Detail-page titles were not left-justified

Header pages call `<Avatar … marginRight={16} />` intending a 16px gap, but MUI's `sx` treats a raw number as a **spacing multiple** (`16 × 8 = 128px`). That oversized gap pushed the email/name toward the middle, making titles look centered. Confirmed on a live page: the avatar's computed `margin-right` was literally `128px`.

Fixed at the `Avatar` component by rendering the numeric prop as explicit pixels, which corrects every caller at once:
- Organization member / guest / account pages (`OrganizationUserPage`)
- Customer page (`CustomerPage`)
- Network share page (`SharePage`)

**Before:** avatar pinned left, title floating ~128px to the right (reads as centered).
**After:** avatar + title sit together at the left, aligned with the content below.

### 2. Products empty-state "+" spacing

The "Create your first product" button used `<Icon name="plus" inline />`. The `inline` prop applies a **left** margin (for *trailing* icons), so the leading "+" had no gap before the text (`+CREATE YOUR FIRST PRODUCT`). Switched to `inlineLeft` (right margin), matching the in-button leading-icon idiom used elsewhere (e.g. `FilesPage`). Also fixed the block's indentation inside `<Container>`.

## Test plan
- [x] Verified on a real logged-in guest page that the corrected 16px margin left-justifies the title, aligned with the section content below.
- [x] Confirmed the numeric `marginRight` now computes to `16px` (was `128px`).
- [ ] Spot-check member, account, customer, and network share page titles.
- [ ] Spot-check the products empty state renders `+ Create your first product` with proper spacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)