### PR TITLE
feat(platforms): add Teltonika platform type (1281)

### DIFF
--- a/frontend/src/platforms/index.ts
+++ b/frontend/src/platforms/index.ts
@@ -59,6 +59,7 @@ class Platforms {
     'openwrt',
     'raspberrypi',
     'remoteit',
+    'teltonika',
     'this',
     'tinkerboard',
     'toa',

--- a/frontend/src/platforms/teltonika/index.tsx
+++ b/frontend/src/platforms/teltonika/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { platforms } from '..'
+
+const Component = ({ darkMode, ...props }) => {
+  const base = darkMode ? '#fff' : '#001A77'
+  return (
+    <svg viewBox="120 120 272 272" version="1.1" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <title>Teltonika</title>
+      <path
+        fill={base}
+        d="m333.421 331.002-72.438-75.113 72.438-75.002 26.039 27.072 32.04-33.174-32.04-33.285-32.04 33.285-32.147-33.285-32.04 33.285-32.147-33.285L120.5 256l110.586 114.5 32.147-33.174 32.04 33.174 32.147-33.174 32.04 33.174 32.04-33.174-32.04-33.174zm-128.267 0-72.438-75.113 72.438-74.891 26.039 26.961L184.687 256l46.506 48.152zm64.08 0-72.438-75.113 72.438-75.002 26.039 26.961-46.399 48.041 46.399 48.152z"
+      />
+    </svg>
+  )
+}
+
+platforms.register({
+  id: 'teltonika',
+  name: 'Teltonika',
+  component: Component,
+  types: { 1281: 'Teltonika' },
+})


### PR DESCRIPTION
Adds Teltonika as a platform type, following the same pattern as TOA (#1132).

- `frontend/src/platforms/teltonika/index.tsx` — registers `id: 'teltonika'`, `types: { 1281: 'Teltonika' }`
- `frontend/src/platforms/index.ts` — adds `'teltonika'` to the `installed` list

### Logo handling

The supplied brand SVG is a white square with navy `#001A77` chevrons. Two adjustments to make it work as a platform icon:

- **Dropped the white background square.** Every other platform icon is transparent, and the square would have rendered as a white block in dark mode. The gaps between the chevrons are holes in the path itself (sub-paths with opposite winding), not white paint layered on top, so they survive the removal — verified by rendering.
- **Tightened the viewBox** from `0 0 512 512` to `120 120 272 272`. The mark occupied only the middle ~53% of the original box and would have rendered noticeably smaller than neighboring icons in list rows. Still centered on 256,256.

Colour is a single `darkMode` swap — `#001A77` on light, `#fff` on dark — matching the convention used by TOA, Amnimo, Alpine, etc.

### Verification

- `npm run typecheck` passes
- Rendered both themes at full size and at 28px list size
- Booted the app with `targetPlatform` temporarily forced to `1281` to confirm the icon in situ; that preview edit is not part of this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
