### PR TITLE
feat(i18n): extract settings & account pages (batch 3)

### DIFF
--- a/frontend/src/i18n/locales/de/app.json
+++ b/frontend/src/i18n/locales/de/app.json
@@ -1,6 +1,8 @@
 {
   "common": {
-    "areYouSure": "Sind Sie sicher?"
+    "areYouSure": "Sind Sie sicher?",
+    "save": "Speichern",
+    "saving": "Wird gespeichert"
   },
   "nav": {
     "account": "Konto",
@@ -94,5 +96,39 @@
       "label": "Deinstallieren",
       "subLabel": "Meldet dieses Gerät ab, entfernt vollständig alle gespeicherten Daten und deinstalliert den Systemagenten sowie die Kommandozeilen-Tools. Führen Sie dies aus, bevor Sie die Anwendung von Ihrem System entfernen. Kann nur vom Gerätebesitzer ausgeführt werden."
     }
+  },
+  "settings": {
+    "accessKeys": "Zugriffsschlüssel",
+    "accountDeletion": "Konto löschen",
+    "application": "Anwendung",
+    "billing": "Abrechnung",
+    "connectedApps": "Verbundene Apps",
+    "connectionDefaults": "Verbindungsstandards",
+    "docs": "Dokumentation",
+    "email": "E-Mail",
+    "emailLanguage": "E-Mail-Sprache",
+    "graphs": "Diagramme",
+    "gravatarEdit": "Um Ihr Profilbild zu bearbeiten oder hinzuzufügen, besuchen Sie bitte",
+    "gravatarImported": "Ihr Profilbild wird vom kostenlosen Dienst Gravatar importiert.",
+    "invalidUrl": "Bitte geben Sie eine gültige URL ein",
+    "license": "Lizenz",
+    "memberSince": "Mitglied seit",
+    "notificationMethod": "Methode",
+    "notifications": "Benachrichtigungen",
+    "notifyEmail": "E-Mail",
+    "notifySystem": "Systembenachrichtigung",
+    "notifyWebhook": "Webhook",
+    "profile": "Profil",
+    "security": "Sicherheit",
+    "signOutEverywhere": "Überall abmelden",
+    "signOutEverywhereButton": "Überall abmelden",
+    "signOutEverywhereDescription": "Dies meldet Sie überall von Remote.It ab, wo Sie derzeit angemeldet sind.",
+    "subscription": "Abonnement",
+    "tags": "Tags",
+    "testSettings": "Testeinstellungen",
+    "title": "Einstellungen",
+    "urlEndpoint": "URL-Endpunkt",
+    "visitWeb": "Remote.It im Web besuchen",
+    "webhookHelp": "Verwenden Sie eine öffentliche HTTPS-URL. Der Endpunkt muss POST akzeptieren und innerhalb von 5 Sekunden mit 200 antworten."
   }
 }

--- a/frontend/src/i18n/locales/en/app.json
+++ b/frontend/src/i18n/locales/en/app.json
@@ -1,6 +1,8 @@
 {
   "common": {
-    "areYouSure": "Are you sure?"
+    "areYouSure": "Are you sure?",
+    "save": "Save",
+    "saving": "Saving"
   },
   "nav": {
     "account": "Account",
@@ -94,5 +96,39 @@
       "label": "Uninstall",
       "subLabel": "De-register this device, completely remove all saved data, and uninstall the system agent and command line tools. Do this before removing the application from your system. Can only be done by the device owner."
     }
+  },
+  "settings": {
+    "accessKeys": "Access Keys",
+    "accountDeletion": "Account deletion",
+    "application": "Application",
+    "billing": "Billing",
+    "connectedApps": "Connected Apps",
+    "connectionDefaults": "Connection Defaults",
+    "docs": "Docs",
+    "email": "Email",
+    "emailLanguage": "Email Language",
+    "graphs": "Graphs",
+    "gravatarEdit": "To edit or add a profile image please visit",
+    "gravatarImported": "Your profile picture is imported from the free service Gravatar.",
+    "invalidUrl": "Please provide a valid URL",
+    "license": "License",
+    "memberSince": "Member since",
+    "notificationMethod": "Method",
+    "notifications": "Notifications",
+    "notifyEmail": "Email",
+    "notifySystem": "System notification",
+    "notifyWebhook": "Webhook",
+    "profile": "Profile",
+    "security": "Security",
+    "signOutEverywhere": "Sign out everywhere",
+    "signOutEverywhereButton": "Sign Out Everywhere",
+    "signOutEverywhereDescription": "This logs you out of Remote.It everywhere you're logged in.",
+    "subscription": "Subscription",
+    "tags": "Tags",
+    "testSettings": "Test Settings",
+    "title": "Settings",
+    "urlEndpoint": "URL endpoint",
+    "visitWeb": "Visit Remote.It on the web",
+    "webhookHelp": "Use a public HTTPS URL. Endpoint must accept POST and return 200 within 5 seconds."
   }
 }

--- a/frontend/src/i18n/locales/es/app.json
+++ b/frontend/src/i18n/locales/es/app.json
@@ -1,6 +1,8 @@
 {
   "common": {
-    "areYouSure": "¿Estás seguro?"
+    "areYouSure": "¿Estás seguro?",
+    "save": "Guardar",
+    "saving": "Guardando"
   },
   "nav": {
     "account": "Cuenta",
@@ -94,5 +96,39 @@
       "label": "Desinstalar",
       "subLabel": "Da de baja este dispositivo, elimina por completo todos los datos guardados y desinstala el agente del sistema y las herramientas de línea de comandos. Haz esto antes de eliminar la aplicación de tu sistema. Solo puede hacerlo el propietario del dispositivo."
     }
+  },
+  "settings": {
+    "accessKeys": "Claves de acceso",
+    "accountDeletion": "Eliminación de cuenta",
+    "application": "Aplicación",
+    "billing": "Facturación",
+    "connectedApps": "Aplicaciones conectadas",
+    "connectionDefaults": "Valores predeterminados de conexión",
+    "docs": "Documentación",
+    "email": "Correo electrónico",
+    "emailLanguage": "Idioma del correo electrónico",
+    "graphs": "Gráficos",
+    "gravatarEdit": "Para editar o añadir una imagen de perfil, visita",
+    "gravatarImported": "Tu imagen de perfil se importa del servicio gratuito Gravatar.",
+    "invalidUrl": "Introduce una URL válida",
+    "license": "Licencia",
+    "memberSince": "Miembro desde",
+    "notificationMethod": "Método",
+    "notifications": "Notificaciones",
+    "notifyEmail": "Correo electrónico",
+    "notifySystem": "Notificación del sistema",
+    "notifyWebhook": "Webhook",
+    "profile": "Perfil",
+    "security": "Seguridad",
+    "signOutEverywhere": "Cerrar sesión en todas partes",
+    "signOutEverywhereButton": "Cerrar sesión en todas partes",
+    "signOutEverywhereDescription": "Esto cierra tu sesión de Remote.It en todos los lugares donde has iniciado sesión.",
+    "subscription": "Suscripción",
+    "tags": "Etiquetas",
+    "testSettings": "Configuración de prueba",
+    "title": "Configuración",
+    "urlEndpoint": "Endpoint de URL",
+    "visitWeb": "Visitar Remote.It en la web",
+    "webhookHelp": "Usa una URL HTTPS pública. El endpoint debe aceptar POST y devolver 200 en un plazo de 5 segundos."
   }
 }

--- a/frontend/src/i18n/locales/ja/app.json
+++ b/frontend/src/i18n/locales/ja/app.json
@@ -1,6 +1,8 @@
 {
   "common": {
-    "areYouSure": "本当によろしいですか?"
+    "areYouSure": "本当によろしいですか?",
+    "save": "保存",
+    "saving": "保存中"
   },
   "nav": {
     "account": "アカウント",
@@ -94,5 +96,39 @@
       "label": "アンインストール",
       "subLabel": "このデバイスの登録を解除し、保存されたすべてのデータを完全に削除して、システムエージェントとコマンドラインツールをアンインストールします。アプリケーションをシステムから削除する前に実行してください。デバイスの所有者のみが実行できます。"
     }
+  },
+  "settings": {
+    "accessKeys": "アクセスキー",
+    "accountDeletion": "アカウントの削除",
+    "application": "アプリケーション",
+    "billing": "請求",
+    "connectedApps": "連携アプリ",
+    "connectionDefaults": "接続のデフォルト設定",
+    "docs": "ドキュメント",
+    "email": "メール",
+    "emailLanguage": "メールの言語",
+    "graphs": "グラフ",
+    "gravatarEdit": "プロフィール画像を編集または追加するには、次のリンクからアクセスしてください:",
+    "gravatarImported": "プロフィール画像は無料サービスのGravatarからインポートされています。",
+    "invalidUrl": "有効なURLを入力してください",
+    "license": "ライセンス",
+    "memberSince": "登録日",
+    "notificationMethod": "方法",
+    "notifications": "通知",
+    "notifyEmail": "メール",
+    "notifySystem": "システム通知",
+    "notifyWebhook": "Webhook",
+    "profile": "プロフィール",
+    "security": "セキュリティ",
+    "signOutEverywhere": "すべてのデバイスからサインアウト",
+    "signOutEverywhereButton": "すべてのデバイスからサインアウト",
+    "signOutEverywhereDescription": "この操作を行うと、ログイン中のすべての場所からRemote.Itがサインアウトされます。",
+    "subscription": "サブスクリプション",
+    "tags": "タグ",
+    "testSettings": "テスト設定",
+    "title": "設定",
+    "urlEndpoint": "URLエンドポイント",
+    "visitWeb": "Remote.Itのウェブサイトにアクセス",
+    "webhookHelp": "公開されているHTTPS URLを使用してください。エンドポイントはPOSTを受け付け、5秒以内に200を返す必要があります。"
   }
 }

--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import browser from '../services/browser'
 import { List, Typography, Tooltip, ButtonBase } from '@mui/material'
+import { useTranslation } from 'react-i18next'
 import { ListItemLocation } from '../components/ListItemLocation'
 import { windowOpen } from '../services/browser'
 import { Container } from '../components/Container'
@@ -9,13 +10,14 @@ import { Logo } from '@common/brand/Logo'
 import { Icon } from '../components/Icon'
 
 export const AccountPage: React.FC = () => {
+  const { t } = useTranslation()
   return (
     <Container
       gutterBottom
       header={
         <>
           <Typography variant="h1" gutterBottom>
-            <Tooltip title="Visit Remote.It on the web">
+            <Tooltip title={t('settings.visitWeb', 'Visit Remote.It on the web')}>
               <ButtonBase onClick={() => windowOpen('https://remote.it')}>
                 <Logo width={110} />
               </ButtonBase>
@@ -26,25 +28,30 @@ export const AccountPage: React.FC = () => {
     >
       <List>
         <ListItemLocation
-          title="Profile"
+          title={t('settings.profile', 'Profile')}
           to="/account/overview"
           match={['/account', '/account/overview']}
           icon="user-large"
           exactMatch
           dense
         />
-        <ListItemLocation title="Security" to="/account/security" icon="lock" dense />
+        <ListItemLocation title={t('settings.security', 'Security')} to="/account/security" icon="lock" dense />
         <BillingUI>
-          <ListItemLocation title="Subscription" to="/account/plans" icon="shopping-cart" dense>
+          <ListItemLocation title={t('settings.subscription', 'Subscription')} to="/account/plans" icon="shopping-cart" dense>
             {!browser.hasBilling && <Icon name="launch" size="sm" color="grayDark" inlineLeft fixedWidth />}
           </ListItemLocation>
-          <ListItemLocation title="Billing" to="/account/billing" icon="credit-card-front" dense>
+          <ListItemLocation title={t('settings.billing', 'Billing')} to="/account/billing" icon="credit-card-front" dense>
             {!browser.hasBilling && <Icon name="launch" size="sm" color="grayDark" inlineLeft fixedWidth />}
           </ListItemLocation>
         </BillingUI>
-        <ListItemLocation title="License" to="/account/license" icon="id-badge" dense />
-        <ListItemLocation title="Access Keys" to="/account/accessKey" icon="key" dense />
-        <ListItemLocation title="Connected Apps" to="/account/connected" icon="puzzle-piece-simple" dense />
+        <ListItemLocation title={t('settings.license', 'License')} to="/account/license" icon="id-badge" dense />
+        <ListItemLocation title={t('settings.accessKeys', 'Access Keys')} to="/account/accessKey" icon="key" dense />
+        <ListItemLocation
+          title={t('settings.connectedApps', 'Connected Apps')}
+          to="/account/connected"
+          icon="puzzle-piece-simple"
+          dense
+        />
       </List>
     </Container>
   )

--- a/frontend/src/pages/NotificationsPage/NotificationsMode.tsx
+++ b/frontend/src/pages/NotificationsPage/NotificationsMode.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { TextField, Button, List, Typography } from '@mui/material'
+import { useTranslation } from 'react-i18next'
 import { Gutters } from '../../components/Gutters'
 import { ListItemSwitch } from '../../components/ListItemSwitch'
 import { Link } from '../../components/Link'
@@ -13,6 +14,7 @@ export const NotificationMode: React.FC = () => {
     (state: State) => state.user.notificationSettings
   )
   const dispatch = useDispatch<Dispatch>()
+  const { t } = useTranslation()
   const { updateNotificationSettings } = dispatch.user
   const [webHookUrl, setWebhookUrl] = useState<string>(notificationUrl || '')
   const [loading, setLoading] = useState<boolean>(false)
@@ -69,9 +71,13 @@ export const NotificationMode: React.FC = () => {
   return (
     <>
       <List>
-        <ListItemSwitch label="System notification" checked={desktopNotifications} onClick={onSystemChange} />
-        <ListItemSwitch label="Email" checked={emailNotifications} onClick={onEmailChange} />
-        <ListItemSwitch label="Webhook" checked={urlNotifications} onClick={onWebChange} />
+        <ListItemSwitch
+          label={t('settings.notifySystem', 'System notification')}
+          checked={desktopNotifications}
+          onClick={onSystemChange}
+        />
+        <ListItemSwitch label={t('settings.notifyEmail', 'Email')} checked={emailNotifications} onClick={onEmailChange} />
+        <ListItemSwitch label={t('settings.notifyWebhook', 'Webhook')} checked={urlNotifications} onClick={onWebChange} />
       </List>
       <Gutters inset="icon" top={null}>
         <Quote margin={null}>
@@ -79,17 +85,17 @@ export const NotificationMode: React.FC = () => {
             disabled={!urlNotifications}
             onChange={e => changeWebHookUrl(e.currentTarget.value.trim())}
             value={webHookUrl}
-            label="URL endpoint"
+            label={t('settings.urlEndpoint', 'URL endpoint')}
             placeholder="https://example.com/webhooks/remoteit"
             required
             variant="filled"
             error={error}
             fullWidth
-            helperText={error ? 'Please provide a valid URL' : undefined}
+            helperText={error ? t('settings.invalidUrl', 'Please provide a valid URL') : undefined}
           />
           <Typography variant="caption" color="text.secondary" component="p" marginTop={2} marginBottom={1}>
-            Use a public HTTPS URL. Endpoint must accept POST and return 200 within 5 seconds.{' '}
-            <Link href="https://docs.remote.it/developer-tools/webhooks">Docs</Link>
+            {t('settings.webhookHelp', 'Use a public HTTPS URL. Endpoint must accept POST and return 200 within 5 seconds.')}{' '}
+            <Link href="https://docs.remote.it/developer-tools/webhooks">{t('settings.docs', 'Docs')}</Link>
           </Typography>
           <Button
             variant="contained"
@@ -98,7 +104,7 @@ export const NotificationMode: React.FC = () => {
             disabled={error || loading || !changed}
             size="small"
           >
-            {loading ? 'Saving' : 'Save'}
+            {loading ? t('common.saving', 'Saving') : t('common.save', 'Save')}
           </Button>
         </Quote>
       </Gutters>

--- a/frontend/src/pages/NotificationsPage/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage/NotificationsPage.tsx
@@ -1,20 +1,22 @@
 import React from 'react'
 import { Container } from '../../components/Container'
 import { Typography } from '@mui/material'
+import { useTranslation } from 'react-i18next'
 import { Title } from '../../components/Title'
 import { NotificationMode } from './NotificationsMode'
 
 export const NotificationsPage: React.FC = () => {
+  const { t } = useTranslation()
   return (
     <Container
       gutterBottom
       header={
         <Typography variant="h1" gutterBottom>
-          <Title>Notifications</Title>
+          <Title>{t('settings.notifications', 'Notifications')}</Title>
         </Typography>
       }
     >
-      <Typography variant="subtitle1">Method</Typography>
+      <Typography variant="subtitle1">{t('settings.notificationMethod', 'Method')}</Typography>
       <NotificationMode />
     </Container>
   )

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -35,7 +35,7 @@ export const ProfilePage: React.FC = () => {
       header={
         <>
           <Typography variant="h1">
-            <Title>Profile</Title>
+            <Title>{t('settings.profile', 'Profile')}</Title>
           </Typography>
         </>
       }
@@ -52,15 +52,16 @@ export const ProfilePage: React.FC = () => {
       >
         <Avatar email={user.email} size={125} />
         <Typography variant="caption">
-          Your profile picture is imported from the free service Gravatar.
-          <br /> To edit or add a profile image please visit<Link href="https://gravatar.com">gravatar.com.</Link>
+          {t('settings.gravatarImported', 'Your profile picture is imported from the free service Gravatar.')}
+          <br /> {t('settings.gravatarEdit', 'To edit or add a profile image please visit')}
+          <Link href="https://gravatar.com">gravatar.com.</Link>
         </Typography>
       </Gutters>
       <List>
-        <FormDisplay icon={<Icon name="at" />} label="Email" displayValue={user.email} displayOnly />
+        <FormDisplay icon={<Icon name="at" />} label={t('settings.email', 'Email')} displayValue={user.email} displayOnly />
         <FormDisplay
           icon={<Icon name="calendar-star" />}
-          label="Member since"
+          label={t('settings.memberSince', 'Member since')}
           displayValue={<Timestamp date={user.created} />}
           displayOnly
         />
@@ -76,7 +77,7 @@ export const ProfilePage: React.FC = () => {
         />
         <SelectSetting
           icon="envelope"
-          label="Email Language"
+          label={t('settings.emailLanguage', 'Email Language')}
           value={user?.language}
           values={[
             { key: 'en', name: LANGUAGES.en },
@@ -85,7 +86,7 @@ export const ProfilePage: React.FC = () => {
           onChange={value => dispatch.user.changeLanguage(value)}
         />
       </List>
-      <Typography variant="subtitle1">Account deletion</Typography>
+      <Typography variant="subtitle1">{t('settings.accountDeletion', 'Account deletion')}</Typography>
       <DeleteAccountSection user={user} paidPlan={paidPlan} deleteAccount={deleteAccount} />
     </Container>
   )

--- a/frontend/src/pages/SecurityPage.tsx
+++ b/frontend/src/pages/SecurityPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Button, Typography, Divider } from '@mui/material'
+import { useTranslation } from 'react-i18next'
 import { Container } from '../components/Container'
 import { Title } from '../components/Title'
 import { Gutters } from '../components/Gutters'
@@ -9,12 +10,13 @@ import { Dispatch } from '../store'
 import { useDispatch } from 'react-redux'
 
 export const SecurityPage: React.FC = () => {
+  const { t } = useTranslation()
   return (
     <Container
       gutterBottom
       header={
         <Typography variant="h1">
-          <Title>Security</Title>
+          <Title>{t('settings.security', 'Security')}</Title>
         </Typography>
       }
     >
@@ -29,20 +31,23 @@ export const SecurityPage: React.FC = () => {
 
 function GlobalSignOut(): JSX.Element {
   const { auth } = useDispatch<Dispatch>()
+  const { t } = useTranslation()
   const signedOut = () => {
     auth.globalSignOut()
   }
   return (
     <>
       <Typography variant="subtitle1" gutterBottom>
-        Sign out everywhere
+        {t('settings.signOutEverywhere', 'Sign out everywhere')}
       </Typography>
       <Gutters>
-        <Typography variant="body2">This logs you out of Remote.It everywhere you're logged in.</Typography>
+        <Typography variant="body2">
+          {t('settings.signOutEverywhereDescription', "This logs you out of Remote.It everywhere you're logged in.")}
+        </Typography>
       </Gutters>
       <Gutters>
         <Button color="primary" variant="outlined" size="small" onClick={signedOut}>
-          Sign Out Everywhere
+          {t('settings.signOutEverywhereButton', 'Sign Out Everywhere')}
         </Button>
       </Gutters>
     </>

--- a/frontend/src/pages/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { List, Typography } from '@mui/material'
+import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { State } from '../../store'
 import { ListItemLocation } from '../../components/ListItemLocation'
@@ -13,6 +14,7 @@ import { Title } from '../../components/Title'
 export const SettingsPage: React.FC = () => {
   const preferences = useSelector((state: State) => state.backend)
   const feature = useSelector((state: State) => selectLimitsLookup(state))
+  const { t } = useTranslation()
 
   if (!preferences) return null
 
@@ -22,7 +24,7 @@ export const SettingsPage: React.FC = () => {
       header={
         <Gutters>
           <Typography variant="h2">
-            <Title>Settings</Title>
+            <Title>{t('settings.title', 'Settings')}</Title>
             <OutOfBand inline />
           </Typography>
         </Gutters>
@@ -30,19 +32,31 @@ export const SettingsPage: React.FC = () => {
     >
       <List>
         <ListItemLocation
-          title="Application"
+          title={t('settings.application', 'Application')}
           to="/settings/options"
           icon="browser"
           match={['/settings', '/settings/options']}
           exactMatch
           dense
         />
-        {feature.tagging && <ListItemLocation title="Tags" to="/settings/tags" icon="tag" showDisabled dense />}
-        <ListItemLocation title="Graphs" to="/settings/graphs" icon="chart-column" dense />
-        <ListItemLocation title="Notifications" to="/settings/notifications" icon="bell" dense />
-        <ListItemLocation title="Connection Defaults" to="/settings/defaults" icon="object-intersect" dense />
+        {feature.tagging && (
+          <ListItemLocation title={t('settings.tags', 'Tags')} to="/settings/tags" icon="tag" showDisabled dense />
+        )}
+        <ListItemLocation title={t('settings.graphs', 'Graphs')} to="/settings/graphs" icon="chart-column" dense />
+        <ListItemLocation
+          title={t('settings.notifications', 'Notifications')}
+          to="/settings/notifications"
+          icon="bell"
+          dense
+        />
+        <ListItemLocation
+          title={t('settings.connectionDefaults', 'Connection Defaults')}
+          to="/settings/defaults"
+          icon="object-intersect"
+          dense
+        />
         <TestUI>
-          <ListItemLocation title="Test Settings" to="/settings/test" icon="vial" dense />
+          <ListItemLocation title={t('settings.testSettings', 'Test Settings')} to="/settings/test" icon="vial" dense />
         </TestUI>
       </List>
     </Container>


### PR DESCRIPTION
## Summary

Batch 3 of Phase 4 extraction: the **Settings & Account pages** — completing the settings/account area that OptionsPage and ProfilePage started. 34 keys (a new `settings.*` group + two reusable `common.*` keys), fully translated to ja/de/es.

Files: `SettingsPage`, `AccountPage`, `SecurityPage`, `NotificationsPage` + `NotificationsMode`, and the remaining hardcoded strings in `ProfilePage` (Profile title, Gravatar caption, Email / Member-since labels, Email Language, Account deletion).

**Stacked on `i18n/extract-notices` (#1153)** to inherit the parser and plural-check fixes. The diff here is settings-only. Retarget order once things merge: #1152 → #1153 → this.

## Notes

- **Key reuse** — `settings.profile`, `settings.security`, `settings.notifications` each label both a nav item and the corresponding page title, so they're defined once and shared. Added `common.save` / `common.saving` (used by the webhook form) as reusable keys alongside the existing `common.areYouSure`.
- **Sentence-case vs title-case** — "Sign out everywhere" (heading) and "Sign Out Everywhere" (button) are separate English keys; in ja/de/es they translate identically (the casing distinction doesn't map), which is expected.
- **Embedded links** — the Gravatar caption and the webhook help text each end in a link; the sentence and the link label are separate `t()` calls rather than `<Trans>`, keeping the link (`gravatar.com.`, `Docs`) intact. The example webhook URL placeholder is left untranslated (it's a sample URL).
- No plurals or interpolation in this batch.

## Verification

- `i18n:check` passes — 4 locales × 3 namespaces, no missing/dead keys, no empty English.
- `tsc` clean; production build passes.

Untranslated strings elsewhere still fall back to English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
