### PR TITLE
feat(i18n): extract device list chrome (batch 4)

### DIFF
--- a/frontend/src/components/DeviceListEmpty.tsx
+++ b/frontend/src/components/DeviceListEmpty.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import brand from '@common/brand/config'
 import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import { selectDeviceModelAttributes, selectIsFiltered } from '../selectors/devices'
 import { useSelector, useDispatch } from 'react-redux'
 import { State, Dispatch } from '../store'
@@ -14,6 +15,7 @@ import { Body } from './Body'
 
 export const DeviceListEmpty: React.FC = () => {
   const { devices } = useDispatch<Dispatch>()
+  const { t } = useTranslation()
   const isFiltered = useSelector(selectIsFiltered)
   const deviceModel = useSelector(selectDeviceModelAttributes)
   const userAccount = useSelector(isUserAccount)
@@ -24,7 +26,11 @@ export const DeviceListEmpty: React.FC = () => {
     <Body center>
       {noResults ? (
         <Box>
-          <Notice>Your {deviceModel.searched ? 'search' : 'filter'} returned no results</Notice>
+          <Notice>
+            {deviceModel.searched
+              ? t('deviceList.searchNoResults', 'Your search returned no results')
+              : t('deviceList.filterNoResults', 'Your filter returned no results')}
+          </Notice>
         </Box>
       ) : userAccount ? (
         brand.name === 'remoteit' ? (
@@ -33,10 +39,15 @@ export const DeviceListEmpty: React.FC = () => {
               step={1}
               showStart
               guide="aws"
-              instructions="Click the button below to have our device shared with you."
+              instructions={t('deviceList.demoInstructions1', 'Click the button below to have our device shared with you.')}
               autoStart
             >
-              <GuideStep guide="aws" step={2} instructions="Please wait while the device is being shared..." hideArrow>
+              <GuideStep
+                guide="aws"
+                step={2}
+                instructions={t('deviceList.demoInstructions2', 'Please wait while the device is being shared...')}
+                hideArrow
+              >
                 <Button
                   onClick={() => devices.claimDevice({ code: DEMO_DEVICE_CLAIM_CODE })}
                   variant="contained"
@@ -45,23 +56,25 @@ export const DeviceListEmpty: React.FC = () => {
                   sx={{ marginBottom: 2.25 }}
                   disabled={claiming}
                 >
-                  <Icon name={claiming ? 'spinner-third' : 'plus'} spin={claiming} type="solid" inlineLeft /> Demo
-                  Device
+                  <Icon name={claiming ? 'spinner-third' : 'plus'} spin={claiming} type="solid" inlineLeft />{' '}
+                  {t('deviceList.demoDevice', 'Demo Device')}
                 </Button>
               </GuideStep>
             </GuideStep>
             <Typography variant="body2" align="center" color="textSecondary" sx={{ maxWidth: 500, padding: 3 }}>
-              See how simple it is to connect with our AWS demo device, or add your own device from the plus menu in the
-              top left of the screen.
+              {t(
+                'deviceList.demoHelp',
+                'See how simple it is to connect with our AWS demo device, or add your own device from the plus menu in the top left of the screen.'
+              )}
             </Typography>
           </>
         ) : (
           <Stack>
             <Typography variant="body1" align="center">
-              Welcome to Telepath by Cachengo
+              {t('deviceList.cachengoWelcome', 'Welcome to Telepath by Cachengo')}
             </Typography>
             <Typography variant="body2" align="center" color="textSecondary" sx={{ paddingTop: 1, paddingBottom: 4 }}>
-              Get started by renting a Symbiote Node from our distributed cloud.{' '}
+              {t('deviceList.cachengoStart', 'Get started by renting a Symbiote Node from our distributed cloud.')}{' '}
             </Typography>
             <Stack direction="row" justifyContent="center" marginBottom={4}>
               <Icon name="cachengo" size="xxxl" platformIcon fixedWidth />
@@ -73,14 +86,14 @@ export const DeviceListEmpty: React.FC = () => {
                 size="large"
                 sx={{ marginLeft: 2, minWidth: 200, borderRadius: 2 }}
               >
-                <Icon name="cart-shopping" inlineLeft /> Rent-A-Node
+                <Icon name="cart-shopping" inlineLeft /> {t('deviceList.cachengoRent', 'Rent-A-Node')}
               </Button>
             </Stack>
           </Stack>
         )
       ) : (
         <Box>
-          <Notice>This account has no devices</Notice>
+          <Notice>{t('deviceList.noDevices', 'This account has no devices')}</Notice>
         </Box>
       )}
     </Body>

--- a/frontend/src/components/DevicesActionBar.tsx
+++ b/frontend/src/components/DevicesActionBar.tsx
@@ -3,6 +3,7 @@ import { MOBILE_WIDTH } from '../constants'
 import { Box, Divider, Typography, InputLabel } from '@mui/material'
 import { State, Dispatch } from '../store'
 import { useSelector, useDispatch } from 'react-redux'
+import { useTranslation } from 'react-i18next'
 import { selectLimitsLookup, selectPermissions } from '../selectors/organizations'
 import { selectActiveAccountId } from '../selectors/accounts'
 import { getSelectedTags } from '../helpers/selectedHelper'
@@ -32,6 +33,7 @@ export const DevicesActionBar: React.FC<Props> = ({ devices }) => {
   const mobile = containerWidth < MOBILE_WIDTH
   const dispatch = useDispatch<Dispatch>()
   const history = useHistory()
+  const { t } = useTranslation()
 
   const onCreate = async tag => await dispatch.tags.create({ tag, accountId })
 
@@ -79,7 +81,7 @@ export const DevicesActionBar: React.FC<Props> = ({ devices }) => {
     >
       <IconButton
         icon="times"
-        title="Clear selection"
+        title={t('deviceList.clearSelection', 'Clear selection')}
         color="alwaysWhite"
         placement="bottom"
         onClick={() => {
@@ -90,18 +92,18 @@ export const DevicesActionBar: React.FC<Props> = ({ devices }) => {
       <Title sx={{ flexGrow: 0 }}>
         <Typography variant="subtitle1">
           {selected.length}&nbsp;
-          {mobile ? <Icon name="check" inline /> : 'Selected'}
+          {mobile ? <Icon name="check" inline /> : t('deviceList.selected', 'Selected')}
         </Typography>
       </Title>
       <Box sx={{ flexGrow: 1 }} />
       {feature.tagging && canEdit && (
         <>
-          {!mobile && <InputLabel shrink>tags</InputLabel>}
+          {!mobile && <InputLabel shrink>{t('deviceList.tagsLabel', 'tags')}</InputLabel>}
           <TagEditor
             button="plus"
             tags={tags}
             buttonProps={{
-              title: 'Add Tag',
+              title: t('deviceList.addTag', 'Add Tag'),
               color: 'alwaysWhite',
               placement: 'bottom',
               loading: adding,
@@ -113,11 +115,11 @@ export const DevicesActionBar: React.FC<Props> = ({ devices }) => {
           />
           <TagEditor
             button="minus"
-            placeholder="Remove a tag..."
+            placeholder={t('deviceList.removeTagPlaceholder', 'Remove a tag...')}
             allowAdding={false}
             tags={getSelectedTags(devices, selected)}
             buttonProps={{
-              title: 'Remove Tag',
+              title: t('deviceList.removeTag', 'Remove Tag'),
               color: 'alwaysWhite',
               placement: 'bottom',
               loading: removing,
@@ -133,11 +135,11 @@ export const DevicesActionBar: React.FC<Props> = ({ devices }) => {
       {permissions.includes('SCRIPTING') && !mobile && (
         <>
           <InputLabel shrink sx={{ ml: 2 }}>
-            script
+            {t('deviceList.scriptLabel', 'script')}
           </InputLabel>
           <IconButton
             icon="chevron-right"
-            title="Choose Script"
+            title={t('deviceList.chooseScript', 'Choose Script')}
             color="alwaysWhite"
             placement="bottom"
             disabled={!selected.length}
@@ -145,7 +147,7 @@ export const DevicesActionBar: React.FC<Props> = ({ devices }) => {
           />
           <IconButton
             icon="plus"
-            title="New Script"
+            title={t('deviceList.newScript', 'New Script')}
             color="alwaysWhite"
             placement="bottom"
             disabled={!selected.length}

--- a/frontend/src/components/DevicesHeader.tsx
+++ b/frontend/src/components/DevicesHeader.tsx
@@ -2,12 +2,14 @@ import React from 'react'
 import { Container } from './Container'
 import { DevicesActionBars } from './DevicesActionBars'
 import { DevicesApplicationsTabs } from './DevicesApplicationsTabs'
+import { useTranslation } from 'react-i18next'
 import { Notice } from './Notice'
 import { Route } from 'react-router-dom'
 
 type Props = { select?: boolean; devices?: IDevice[]; children?: React.ReactNode }
 
 export const DevicesHeader: React.FC<Props> = ({ select, devices, children }) => {
+  const { t } = useTranslation()
   return (
     <Container
       integrated
@@ -18,7 +20,7 @@ export const DevicesHeader: React.FC<Props> = ({ select, devices, children }) =>
           <DevicesActionBars select={select} devices={devices} />
           <DevicesApplicationsTabs />
           <Route path="/devices/restore">
-            <Notice>Please select a device to restore.</Notice>
+            <Notice>{t('deviceList.selectToRestore', 'Please select a device to restore.')}</Notice>
           </Route>
         </>
       }

--- a/frontend/src/i18n/locales/de/app.json
+++ b/frontend/src/i18n/locales/de/app.json
@@ -4,6 +4,28 @@
     "save": "Speichern",
     "saving": "Wird gespeichert"
   },
+  "deviceList": {
+    "addTag": "Tag hinzufügen",
+    "cachengoRent": "Rent-A-Node",
+    "cachengoStart": "Starten Sie, indem Sie einen Symbiote Node aus unserer verteilten Cloud mieten.",
+    "cachengoWelcome": "Willkommen bei Telepath von Cachengo",
+    "chooseScript": "Skript auswählen",
+    "clearSelection": "Auswahl aufheben",
+    "demoDevice": "Demogerät",
+    "demoHelp": "Erfahren Sie, wie einfach die Verbindung mit unserem AWS-Demogerät ist, oder fügen Sie über das Plus-Menü oben links im Bildschirm Ihr eigenes Gerät hinzu.",
+    "demoInstructions1": "Klicken Sie auf die Schaltfläche unten, um unser Gerät mit Ihnen zu teilen.",
+    "demoInstructions2": "Bitte warten Sie, während das Gerät freigegeben wird...",
+    "filterNoResults": "Ihr Filter hat keine Ergebnisse geliefert",
+    "newScript": "Neues Skript",
+    "noDevices": "Dieses Konto hat keine Geräte",
+    "removeTag": "Tag entfernen",
+    "removeTagPlaceholder": "Tag entfernen...",
+    "scriptLabel": "Skript",
+    "searchNoResults": "Ihre Suche hat keine Ergebnisse geliefert",
+    "selectToRestore": "Bitte wählen Sie ein Gerät zum Wiederherstellen aus.",
+    "selected": "Ausgewählt",
+    "tagsLabel": "Tags"
+  },
   "nav": {
     "account": "Konto",
     "admin": "Admin",

--- a/frontend/src/i18n/locales/en/app.json
+++ b/frontend/src/i18n/locales/en/app.json
@@ -4,6 +4,28 @@
     "save": "Save",
     "saving": "Saving"
   },
+  "deviceList": {
+    "addTag": "Add Tag",
+    "cachengoRent": "Rent-A-Node",
+    "cachengoStart": "Get started by renting a Symbiote Node from our distributed cloud.",
+    "cachengoWelcome": "Welcome to Telepath by Cachengo",
+    "chooseScript": "Choose Script",
+    "clearSelection": "Clear selection",
+    "demoDevice": "Demo Device",
+    "demoHelp": "See how simple it is to connect with our AWS demo device, or add your own device from the plus menu in the top left of the screen.",
+    "demoInstructions1": "Click the button below to have our device shared with you.",
+    "demoInstructions2": "Please wait while the device is being shared...",
+    "filterNoResults": "Your filter returned no results",
+    "newScript": "New Script",
+    "noDevices": "This account has no devices",
+    "removeTag": "Remove Tag",
+    "removeTagPlaceholder": "Remove a tag...",
+    "scriptLabel": "script",
+    "searchNoResults": "Your search returned no results",
+    "selected": "Selected",
+    "selectToRestore": "Please select a device to restore.",
+    "tagsLabel": "tags"
+  },
   "nav": {
     "account": "Account",
     "admin": "Admin",

--- a/frontend/src/i18n/locales/es/app.json
+++ b/frontend/src/i18n/locales/es/app.json
@@ -4,6 +4,28 @@
     "save": "Guardar",
     "saving": "Guardando"
   },
+  "deviceList": {
+    "addTag": "Añadir etiqueta",
+    "cachengoRent": "Rent-A-Node",
+    "cachengoStart": "Empieza alquilando un Symbiote Node desde nuestra nube distribuida.",
+    "cachengoWelcome": "Bienvenido a Telepath de Cachengo",
+    "chooseScript": "Elegir script",
+    "clearSelection": "Borrar selección",
+    "demoDevice": "Dispositivo de demostración",
+    "demoHelp": "Descubre lo sencillo que es conectarte con nuestro dispositivo de demostración de AWS, o añade tu propio dispositivo desde el menú más (+) en la parte superior izquierda de la pantalla.",
+    "demoInstructions1": "Haz clic en el botón de abajo para que compartamos nuestro dispositivo contigo.",
+    "demoInstructions2": "Espera mientras se comparte el dispositivo...",
+    "filterNoResults": "Tu filtro no arrojó resultados",
+    "newScript": "Nuevo script",
+    "noDevices": "Esta cuenta no tiene dispositivos",
+    "removeTag": "Quitar etiqueta",
+    "removeTagPlaceholder": "Quitar una etiqueta...",
+    "scriptLabel": "script",
+    "searchNoResults": "Tu búsqueda no arrojó resultados",
+    "selectToRestore": "Selecciona un dispositivo para restaurar.",
+    "selected": "Seleccionado",
+    "tagsLabel": "etiquetas"
+  },
   "nav": {
     "account": "Cuenta",
     "admin": "Admin",

--- a/frontend/src/i18n/locales/ja/app.json
+++ b/frontend/src/i18n/locales/ja/app.json
@@ -4,6 +4,28 @@
     "save": "保存",
     "saving": "保存中"
   },
+  "deviceList": {
+    "addTag": "タグを追加",
+    "cachengoRent": "Rent-A-Node",
+    "cachengoStart": "分散クラウドから Symbiote Node をレンタルして始めましょう。",
+    "cachengoWelcome": "Cachengo の Telepath へようこそ",
+    "chooseScript": "スクリプトを選択",
+    "clearSelection": "選択を解除",
+    "demoDevice": "デモデバイス",
+    "demoHelp": "AWS デモデバイスへの接続がいかに簡単か確認するか、画面左上のプラスメニューからご自身のデバイスを追加してください。",
+    "demoInstructions1": "下のボタンをクリックすると、デバイスが共有されます。",
+    "demoInstructions2": "デバイスを共有しています。しばらくお待ちください...",
+    "filterNoResults": "フィルターに一致する結果がありません",
+    "newScript": "新しいスクリプト",
+    "noDevices": "このアカウントにはデバイスがありません",
+    "removeTag": "タグを削除",
+    "removeTagPlaceholder": "タグを削除...",
+    "scriptLabel": "スクリプト",
+    "searchNoResults": "検索に一致する結果がありません",
+    "selectToRestore": "復元するデバイスを選択してください。",
+    "selected": "選択中",
+    "tagsLabel": "タグ"
+  },
   "nav": {
     "account": "アカウント",
     "admin": "管理",


### PR DESCRIPTION
## Summary

Batch 4 of Phase 4 — the first slice of the **device/connection surfaces**: the device-list **chrome**. 20 keys (`deviceList.*`) across `DevicesHeader`, `DeviceListEmpty`, and `DevicesActionBar`, translated to ja/de/es.

Covers the empty/no-results states, the AWS demo-device onboarding copy, the Cachengo-brand welcome, and the multi-select action bar (tag/script controls, selection labels).

**Stacked on `i18n/extract-settings` (#1154).**

## Notes / scoping

- **Column labels deferred deliberately.** The device-list column headers come from `Attributes.tsx` — a module-level static registry of ~71 `label:` strings evaluated once at import. Making those translatable and reactive to language changes needs a small architectural change (labels → keys resolved at render time), so it gets its own dedicated batch rather than being rushed in here.
- **Conditional noun split** — `Your {searched ? 'search' : 'filter'} returned no results` became two keys so each language reads naturally.
- **Brand copy** — the Cachengo/Telepath strings render only for that brand build; product names (`Telepath`, `Cachengo`, `Symbiote Node`, `Rent-A-Node`) are kept untranslated, surrounding words localized.
- `DevicesPage` and `DeviceListHeaderCheckbox` had no user-facing strings (pure composition), so they're untouched.

## Verification

- `i18n:check` passes — 4 locales × 3 namespaces, no missing/dead keys, no empty English.
- `tsc` clean; production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
