### PR TITLE
fix(i18n): address Codex review findings

### DIFF
--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 import browser from '../services/browser'
 import useSafeArea from '../hooks/useSafeArea'
 import useCapacitor from '../hooks/useCapacitor'
@@ -34,6 +35,11 @@ import { AnnouncementDialog } from './AnnouncementDialog'
 import { AnnouncementBanner } from './AnnouncementBanner'
 
 export const App: React.FC = () => {
+  // Subscribe the whole app to i18next language changes and lazy-locale loads, so
+  // render-time translations resolved outside React (Attribute label getters,
+  // value functions, date/duration helpers) re-render when the language switches
+  // or a non-English catalog chunk finishes loading.
+  useTranslation()
   const { insets } = useSafeArea()
   const location = useLocation()
   const hideSplashScreen = useCapacitor()

--- a/frontend/src/components/Attributes.tsx
+++ b/frontend/src/components/Attributes.tsx
@@ -50,9 +50,11 @@ export class Attribute<TOptions = IDataOptions> {
   // the `columns.<id>` namespace. Non-string labels (React nodes) pass through
   // unchanged; a missing translation falls back to the original English label.
   get label(): string | React.ReactNode {
-    return typeof this._label === 'string'
-      ? i18n.t(`columns.${this.id}`, { defaultValue: this._label })
-      : this._label
+    // Non-string labels (React nodes) and intentionally-blank labels (e.g. an
+    // actions column) pass through untranslated — translating an empty default
+    // with returnEmptyString:false would otherwise leak the raw `columns.<id>` key.
+    if (typeof this._label !== 'string' || this._label === '') return this._label
+    return i18n.t(`columns.${this.id}`, { defaultValue: this._label })
   }
   set label(value: string | React.ReactNode) {
     this._label = value

--- a/frontend/src/components/Confirm.tsx
+++ b/frontend/src/components/Confirm.tsx
@@ -10,6 +10,7 @@ import {
 } from '@mui/material'
 import { TransitionProps } from '@mui/material/transitions'
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 
 export type ConfirmProps = {
   title?: React.ReactNode
@@ -25,7 +26,7 @@ export type ConfirmProps = {
 
 export const Confirm: React.FC<ConfirmProps> = ({
   title,
-  action = 'Ok',
+  action,
   open,
   onConfirm,
   onDeny,
@@ -33,29 +34,32 @@ export const Confirm: React.FC<ConfirmProps> = ({
   color = 'primary',
   disabled,
   children,
-}) => (
-  <Dialog
-    open={open}
-    maxWidth={maxWidth}
-    TransitionComponent={Transition}
-    transitionDuration={200}
-    onClose={onDeny || onConfirm}
-    fullWidth
-  >
-    <DialogTitle>{title}</DialogTitle>
-    <DialogContent>{children}</DialogContent>
-    <DialogActions>
-      {onDeny && (
-        <Button color="primary" onClick={onDeny}>
-          Cancel
+}) => {
+  const { t } = useTranslation()
+  return (
+    <Dialog
+      open={open}
+      maxWidth={maxWidth}
+      TransitionComponent={Transition}
+      transitionDuration={200}
+      onClose={onDeny || onConfirm}
+      fullWidth
+    >
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent>{children}</DialogContent>
+      <DialogActions>
+        {onDeny && (
+          <Button color="primary" onClick={onDeny}>
+            {t('common.cancel', 'Cancel')}
+          </Button>
+        )}
+        <Button autoFocus variant="contained" color={color} disabled={disabled} onClick={onConfirm}>
+          &nbsp; {action ?? t('common.ok', 'Ok')} &nbsp;
         </Button>
-      )}
-      <Button autoFocus variant="contained" color={color} disabled={disabled} onClick={onConfirm}>
-        &nbsp; {action} &nbsp;
-      </Button>
-    </DialogActions>
-  </Dialog>
-)
+      </DialogActions>
+    </Dialog>
+  )
+}
 
 const Transition = React.forwardRef(function Transition(
   props: TransitionProps & { children: React.ReactElement },

--- a/frontend/src/components/Duration/Duration.tsx
+++ b/frontend/src/components/Duration/Duration.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { useInterval } from '../../hooks/useInterval'
 import { HumanizerOptions } from 'humanize-duration'
-import { humanizeDuration as humanize } from '../../helpers/dateHelper'
+import { humanizeDuration as humanize, relativeTime, getLocale } from '../../helpers/dateHelper'
 
 export const dateDefaults: Intl.DateTimeFormatOptions = {
   year: 'numeric',
@@ -47,16 +47,18 @@ export const Duration: React.FC<Props> = ({
 
   const duration = Math.round((now - startTime) / 1000) * 1000
 
+  const withAgo = (text: string) => (ago ? relativeTime(text) : text)
+
   let display: string
   if (tiered) {
-    const locale = navigator.language
+    const locale = getLocale()
     const date = new Date(startTime)
     if (duration < aDay) {
       // hour:min — "3 hours, 25 minutes" (controlled by humanizeOptions)
-      display = humanize(duration, humanizeOptions) + (ago ? ' ago' : '')
+      display = withAgo(humanize(duration, humanizeOptions))
     } else if (duration < aMonth) {
       // day:hour — "5 days, 3 hours"
-      display = humanize(duration, { largest: 2, units: ['d', 'h'], round: true }) + (ago ? ' ago' : '')
+      display = withAgo(humanize(duration, { largest: 2, units: ['d', 'h'], round: true }))
     } else if (duration < aYear) {
       // month:day — "Feb 17"
       display = date.toLocaleString(locale, { month: 'short', day: 'numeric' })
@@ -67,8 +69,8 @@ export const Duration: React.FC<Props> = ({
   } else {
     display =
       duration > aDay
-        ? new Date(startTime).toLocaleString(navigator.language, dateOptions)
-        : humanize(duration, humanizeOptions) + (ago ? ' ago' : '')
+        ? new Date(startTime).toLocaleString(getLocale(), dateOptions)
+        : withAgo(humanize(duration, humanizeOptions))
   }
 
   return <>{display || '-'}</>

--- a/frontend/src/components/NetworkListTitle.tsx
+++ b/frontend/src/components/NetworkListTitle.tsx
@@ -73,7 +73,7 @@ export const NetworkListTitle: React.FC<Props> = ({
       onClick={noLink ? onClick : undefined}
       title={
         <Title>
-          {networkName(network?.name)}
+          {networkName(network)}
           {expanded ? '' : ' ...'}
         </Title>
       }

--- a/frontend/src/components/RouteSetting.tsx
+++ b/frontend/src/components/RouteSetting.tsx
@@ -7,7 +7,10 @@ import { useDispatch } from 'react-redux'
 import { newConnection, setConnection, getRoute, routeTypeToSettings } from '../helpers/connectionHelper'
 import { SelectSetting } from './SelectSetting'
 
-export const ROUTES: IRoute[] = [
+// Built at call time (not module load) so the labels resolve in the active
+// language and update when the user switches language, rather than being frozen
+// to whatever locale was loaded when this module was first imported.
+export const getRoutes = (): IRoute[] => [
   {
     key: 'failover',
     icon: 'code-branch',
@@ -47,12 +50,13 @@ export const RouteSetting: React.FC<{ service: IService; connection: IConnection
 
   if (!service) return null
 
+  const routes = getRoutes()
   const defaults = newConnection(service)
   const disabled =
     connection.connected || ['p2p', 'proxy'].includes(service.attributes.route || '') || connection.connectLink
   const connectionRoute = getRoute(connection)
   const defaultRoute = getRoute(defaults)
-  const route = ROUTES.find(r => r.key === connectionRoute)
+  const route = routes.find(r => r.key === connectionRoute)
 
   return (
     <SelectSetting
@@ -62,7 +66,7 @@ export const RouteSetting: React.FC<{ service: IService; connection: IConnection
       defaultValue={defaultRoute}
       label={t('routeSetting.label', 'Routing')}
       value={connectionRoute}
-      values={ROUTES.map(r => ({ key: r.key, name: r.name, description: r.description }))}
+      values={routes.map(r => ({ key: r.key, name: r.name, description: r.description }))}
       onChange={route => {
         setOpen(!open)
         const updated = {

--- a/frontend/src/components/ServiceAttributesForm.tsx
+++ b/frontend/src/components/ServiceAttributesForm.tsx
@@ -10,7 +10,7 @@ import { validPort, isFileToken } from '../helpers/connectionHelper'
 import { InlineFileFieldSetting } from './InlineFileFieldSetting'
 import { ListItemCheckbox } from './ListItemCheckbox'
 import { TemplateSetting } from './TemplateSetting'
-import { ROUTES } from './RouteSetting'
+import { getRoutes } from './RouteSetting'
 import { Notice } from './Notice'
 import { Quote } from './Quote'
 
@@ -38,6 +38,7 @@ export const ServiceAttributesForm: React.FC<Props> = ({
   const app = useApplication(undefined, connection)
 
   customTokens = customTokens.length ? customTokens : app.allCustomTokens
+  const routes = getRoutes()
 
   return (
     <>
@@ -66,20 +67,20 @@ export const ServiceAttributesForm: React.FC<Props> = ({
           value={routingLock || attributes.route || ''}
           disabled={!!routingLock || disabled}
           variant="filled"
-          placeholder={routingLock || attributes.route || ROUTES[0].key}
+          placeholder={routingLock || attributes.route || routes[0].key}
           onChange={event => onChange({ ...attributes, route: event.target.value as IRouteType })}
         >
           <MenuItem value="">
             <i>{t('serviceAttributesForm.noDefaultOverride', 'No default override')}</i>
           </MenuItem>
-          {ROUTES.map(route => (
+          {routes.map(route => (
             <MenuItem value={route.key} key={route.key}>
               {route.name}
             </MenuItem>
           ))}
         </TextField>
         <Typography variant="caption">
-          {routingMessage || ROUTES.find(route => route.key === attributes.route)?.description}
+          {routingMessage || routes.find(route => route.key === attributes.route)?.description}
           <i> {t('serviceAttributesForm.routingDesktopOnly', 'Routing is only available on desktop.')}</i>
           <b> {t('serviceAttributesForm.defaultAdaptiveRouting', 'Default adaptive routing')}</b>
         </Typography>

--- a/frontend/src/components/SidebarNav.tsx
+++ b/frontend/src/components/SidebarNav.tsx
@@ -22,6 +22,7 @@ import { ResellerLogo } from './ResellerLogo'
 import { ListItemLink } from './ListItemLink'
 import { isRemoteUI } from '../helpers/uiHelper'
 import { useCounts } from '../hooks/useCounts'
+import { getLocale } from '../helpers/dateHelper'
 import { spacing } from '../styling'
 import { getHasPartner } from '../models/partnerStats'
 
@@ -83,8 +84,8 @@ export const SidebarNav: React.FC = () => {
             {!!counts.active && !counts.memberships ? (
               <Tooltip
                 title={t('nav.connectionsTooltip', {
-                  connections: counts.connections.toLocaleString(),
-                  active: counts.active.toLocaleString(),
+                  connections: counts.connections.toLocaleString(getLocale()),
+                  active: counts.active.toLocaleString(getLocale()),
                   defaultValue: '{{connections}} Connections - {{active}} Connected',
                 })}
                 placement="top"
@@ -92,7 +93,7 @@ export const SidebarNav: React.FC = () => {
               >
                 <Chip
                   size="small"
-                  label={counts.active.toLocaleString()}
+                  label={counts.active.toLocaleString(getLocale())}
                   sx={{ fontWeight: 500 }}
                   variant="filled"
                   color="primary"
@@ -107,13 +108,13 @@ export const SidebarNav: React.FC = () => {
                 >
                   <Tooltip
                     title={t('nav.idleConnections', {
-                      connections: counts.connections.toLocaleString(),
+                      connections: counts.connections.toLocaleString(getLocale()),
                       defaultValue: '{{connections}} Idle Connections',
                     })}
                     placement="top"
                     arrow
                   >
-                    <Chip size="small" label={counts.connections.toLocaleString()} />
+                    <Chip size="small" label={counts.connections.toLocaleString(getLocale())} />
                   </Tooltip>
                 </Badge>
               )
@@ -122,7 +123,7 @@ export const SidebarNav: React.FC = () => {
           <ListItemLocation title={t('nav.devices', 'Devices')} icon="router" to="/devices" match="/devices" dense>
             {!!counts.devices && (
               <Tooltip title={t('nav.totalDevices', 'Total Devices')} placement="top" arrow>
-                <Chip size="small" label={counts.devices.toLocaleString()} />
+                <Chip size="small" label={counts.devices.toLocaleString(getLocale())} />
               </Tooltip>
             )}
           </ListItemLocation>
@@ -135,7 +136,7 @@ export const SidebarNav: React.FC = () => {
           >
             {!!counts.networks && (
               <Tooltip title={t('nav.totalNetworks', 'Total Networks')} placement="top" arrow>
-                <Chip size="small" label={counts.networks.toLocaleString()} />
+                <Chip size="small" label={counts.networks.toLocaleString(getLocale())} />
               </Tooltip>
             )}
           </ListItemLocation>

--- a/frontend/src/helpers/dateHelper.ts
+++ b/frontend/src/helpers/dateHelper.ts
@@ -11,6 +11,12 @@ export const getLocale = () => i18n.resolvedLanguage || window.navigator.languag
 export const humanizeDuration = (ms: number, options: HumanizerOptions = {}) =>
   humanize(ms, { language: getLocale(), fallbacks: ['en'], ...options })
 
+// Wrap a humanized duration as a localized relative-past phrase. Word order is
+// language-specific (en "3 days ago", de "vor 3 Tagen", ja "3日前", es "hace 3 días"),
+// so the ordering lives in the catalog rather than a hard-coded English suffix.
+export const relativeTime = (duration: string): string =>
+  i18n.t('duration.ago', { defaultValue: '{{duration}} ago', duration })
+
 export function isToday(dateToCheck: Date): boolean {
   const today = new Date().toLocaleDateString()
   const check = dateToCheck.toLocaleDateString()

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -40,9 +40,11 @@ i18n
   .use(lazyBackend)
   .use(initReactI18next)
   .init({
-    // The resolved language is driven by redux (ui.setLanguage); 'en' here is a
-    // safe boot value overwritten before first paint.
-    lng: 'en',
+    // Resolve the language at boot from the OS/browser (navigator.language) so
+    // signed-out screens (Cognito sign-in, signup, MFA) follow the system locale
+    // immediately. The persisted per-account override is session-scoped and thus
+    // unavailable until sign-in, when ui.setLanguage re-applies it.
+    lng: resolveLanguage(),
     fallbackLng: 'en',
     ns: NAMESPACES as unknown as string[],
     defaultNS: 'app',

--- a/frontend/src/i18n/locales/de/app.json
+++ b/frontend/src/i18n/locales/de/app.json
@@ -939,6 +939,9 @@
     "transferInfo": "Die Geräteübertragung dauert in der Regel nur wenige Sekunden. Sobald der Vorgang abgeschlossen ist, erhalten Sie und der neue Eigentümer eine E-Mail.",
     "transferringTo": "Sie übertragen „{{name}}“ an einen neuen Eigentümer."
   },
+  "duration": {
+    "ago": "vor {{duration}}"
+  },
   "eventMessage": {
     "allowed": "erlaubt",
     "and": "und",

--- a/frontend/src/i18n/locales/en/app.json
+++ b/frontend/src/i18n/locales/en/app.json
@@ -939,6 +939,9 @@
     "transferInfo": "Device transfer typically takes a few seconds to complete. An email will be sent to you and the new owner when the process is completed.",
     "transferringTo": "You are transferring \"{{name}}\" to a new owner."
   },
+  "duration": {
+    "ago": "{{duration}} ago"
+  },
   "eventMessage": {
     "allowed": "allowed",
     "and": "and",

--- a/frontend/src/i18n/locales/es/app.json
+++ b/frontend/src/i18n/locales/es/app.json
@@ -956,6 +956,9 @@
     "transferInfo": "La transferencia del dispositivo suele completarse en unos segundos. Se enviará un correo electrónico a ti y al nuevo propietario cuando finalice el proceso.",
     "transferringTo": "Estás transfiriendo \"{{name}}\" a un nuevo propietario."
   },
+  "duration": {
+    "ago": "hace {{duration}}"
+  },
   "eventMessage": {
     "allowed": "permitido",
     "and": "y",

--- a/frontend/src/i18n/locales/ja/app.json
+++ b/frontend/src/i18n/locales/ja/app.json
@@ -922,6 +922,9 @@
     "transferInfo": "デバイスの譲渡は通常数秒で完了します。処理が完了すると、あなたと新しい所有者にメールが送信されます。",
     "transferringTo": "「{{name}}」を新しい所有者に譲渡しています。"
   },
+  "duration": {
+    "ago": "{{duration}}前"
+  },
   "eventMessage": {
     "allowed": "許可されました",
     "and": "および",

--- a/frontend/src/models/networks.ts
+++ b/frontend/src/models/networks.ts
@@ -63,18 +63,22 @@ export const recentNetwork: INetwork = {
   icon: 'clock-rotate-left',
 }
 
-// Built-in/system network group names are English constants; translate them for
-// display (keys hand-maintained in the catalogs). User-named networks — anything
-// not in this map — pass through unchanged.
+// Built-in/system networks are synthetic groups with reserved ids (never used by
+// real user networks); their English names are translated for display via
+// hand-maintained catalog keys. Gating on the reserved id — not the name — means a
+// user who names their own network "Local"/"Recent"/etc. is never relabeled.
+const SYSTEM_NETWORK_IDS = new Set([DEFAULT_ID, 'recent', 'public'])
 const SYSTEM_NETWORK_KEYS: ILookup<string> = {
   Active: 'network.active',
   'Cloud Proxy': 'network.cloudProxy',
   Recent: 'network.recent',
   Local: 'network.local',
-  Personal: 'network.personal',
 }
-export const networkName = (name?: string): string =>
-  (name && SYSTEM_NETWORK_KEYS[name] ? i18n.t(SYSTEM_NETWORK_KEYS[name], { defaultValue: name }) : name) || ''
+export const networkName = (network?: INetwork): string => {
+  if (!network) return ''
+  const key = SYSTEM_NETWORK_IDS.has(network.id) ? SYSTEM_NETWORK_KEYS[network.name] : undefined
+  return (key ? i18n.t(key, { defaultValue: network.name }) : network.name) || ''
+}
 
 export type addConnectionProps = {
   serviceId: string

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -53,7 +53,7 @@ export const ProfilePage: React.FC = () => {
         <Avatar email={user.email} size={125} />
         <Typography variant="caption">
           {t('settings.gravatarImported', 'Your profile picture is imported from the free service Gravatar.')}
-          <br /> {t('settings.gravatarEdit', 'To edit or add a profile image please visit')}
+          <br /> {t('settings.gravatarEdit', 'To edit or add a profile image please visit')}{' '}
           <Link href="https://gravatar.com">gravatar.com.</Link>
         </Typography>
       </Gutters>


### PR DESCRIPTION
Addresses the Codex review findings across the i18n PR stack. Verified each against source before fixing.

## P1
- **Signed-out screens now follow the OS locale.** `i18n` init resolved `lng` from a hard-coded `'en'` only, and the language was re-resolved solely on sign-in — so translated Cognito sign-in/signup/MFA screens always rendered English. Init now calls `resolveLanguage()` (→ `navigator.language`); the persisted per-account override is session-scoped and still re-applied by `ui.setLanguage` after sign-in.

## P2 — concrete bugs
- **Confirmation dialog buttons** (`Confirm.tsx`) were hard-coded `Ok`/`Cancel` → now `common.ok`/`common.cancel`. Affects every confirm dialog app-wide.
- **Relative dates** (`Duration.tsx`) appended a literal English `" ago"` (`"3 Tage ago"`) and formatted month/year/date branches with `navigator.language`. Now uses a translated `duration.ago` phrase (word-order per locale: `vor {{d}}` / `{{d}}前` / `hace {{d}}`) and `getLocale()`.
- **Empty attribute labels** (`Attributes.tsx`) leaked the raw `columns.<id>` key (e.g. the enterprise-license actions column) under `returnEmptyString:false` → blank labels now pass through untranslated.
- **`networkName`** classified system networks by *name*, so a user network named "Local"/"Recent"/etc. got relabeled. Now gated on the reserved synthetic id (`local`/`recent`/`public`).
- **Gravatar link** ran into preceding text in de/es (`bittegravatar.com`) → added `{' '}`.
- **Sidebar count/tooltip** number formatting now uses `getLocale()`.

## P2 — reactivity (module-level strings didn't re-resolve)
- `RouteSetting.ROUTES` was evaluated at import (while i18n was still `en`) → converted to `getRoutes()` resolved at render (also updated `ServiceAttributesForm`).
- Added `useTranslation()` at the `App` root so render-time translations resolved outside React (Attribute label getters, value functions, date/duration helpers) re-render on language switch and when a lazy locale chunk finishes loading.

## Deliberately deferred
- **`applications.ts` launch-method labels** (`Command`/`Terminal`/…) are set in constructors and memoized by `selectApplication`, so they stay stale on a *live* language switch until the service/connection changes. Fixing this cleanly means a getter refactor in the shared `common/` package; deferred as low-impact (narrow surface, only on live switch) rather than risk an untested shared-package change.
- **Admin table header collisions** (`created` → "Created date", `license`) — left as-is: admin pages are internal-only and don't need translation.

Verification: `tsc` clean, production build clean (locale chunks code-split), i18n parity check passes.