### PR TITLE
fix(admin): open view-as-user in the web portal from the desktop app

### DIFF
--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -11,6 +11,7 @@ export const AUTH_API_URL = env.VITE_AUTH_API_URL || env.AUTH_API_URL || 'https:
 export const GRAPHQL_API = env.VITE_GRAPHQL_API || 'https://api.remote.it/graphql/v1'
 export const GRAPHQL_BETA_API = env.VITE_GRAPHQL_BETA_API || 'https://api.remote.it/graphql/beta'
 export const PORTAL = (env.VITE_PORTAL || env.PORTAL) === 'true' ? true : false
+export const PORTAL_URL = env.VITE_PORTAL_URL || brand.package?.homepage || 'https://app.remote.it'
 export const DEVELOPER_KEY = env.VITE_DEVELOPER_KEY || 'Mjc5REIzQUQtMTQyRC00NTcxLTlGRDktMTVGNzVGNDYxQkE3'
 
 export const PROTOCOL = env.PROTOCOL || `${brand.name}://`

--- a/frontend/src/pages/AdminUsersPage/AdminUserDetailPage.tsx
+++ b/frontend/src/pages/AdminUsersPage/AdminUserDetailPage.tsx
@@ -10,6 +10,7 @@ import { Body } from '../../components/Body'
 import { LoadingMessage } from '../../components/LoadingMessage'
 import { IconButton } from '../../buttons/IconButton'
 import { spacing } from '../../styling'
+import { PORTAL_URL } from '../../constants'
 import { Dispatch, State } from '../../store'
 import browser from '../../services/browser'
 import { windowOpen } from '../../services/browser'
@@ -59,7 +60,12 @@ export const AdminUserDetailPage: React.FC = () => {
 
   const handleViewAsUser = () => {
     const viewAs = `/devices?viewAs=${user.id},${encodeURIComponent(user.email || '')}`
-    if (browser.isElectron || browser.isMobile) {
+    // The desktop app shows local backend data, so view as has to run in the web portal
+    if (browser.isElectron) {
+      windowOpen(`${PORTAL_URL}/#${viewAs}`, '_blank', true)
+      return
+    }
+    if (browser.isMobile) {
       history.push(viewAs)
       return
     }


### PR DESCRIPTION
## Problem

The admin **View as** eye icon doesn't work in the desktop app. The desktop app renders data from the local backend, so navigating in-app with the `viewAs` param never produces the target user's view.

## Change

In Electron, the eye icon now launches the web portal in the system browser instead of pushing an in-app route:

- Added `PORTAL_URL` to `frontend/src/constants.ts` (`VITE_PORTAL_URL` → brand `package.homepage` → `https://app.remote.it`), so it can be pointed at a non-production portal.
- `AdminUserDetailPage.handleViewAsUser` opens `${PORTAL_URL}/#/devices?viewAs=<id>,<email>` externally when `browser.isElectron`.

Mobile keeps the in-app `history.push`, and web keeps opening a new tab of itself — both unchanged.

## Notes

- Electron's `windowOpen` goes through `window.open` → `setWindowOpenHandler` in `electron/src/ElectronApp.ts`, which calls `shell.openExternal`, so the default browser handles it.
- The admin must already be signed in at app.remote.it in that browser; the desktop session isn't shared, so they'll hit sign-in first if not.

## Testing

- `tsc --noEmit` passes.
- Not yet click-tested in a running Electron build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)