### PR TITLE
feat: system-wide Devices page in the Admin section

### DIFF
--- a/frontend/src/components/AdminSidebarNav.tsx
+++ b/frontend/src/components/AdminSidebarNav.tsx
@@ -57,6 +57,17 @@ export const AdminSidebarNav: React.FC = () => {
 
       <ListItemButton
         dense
+        selected={currentPath.includes('/admin/devices')}
+        onClick={() => handleNavClick('/admin/devices')}
+      >
+        <ListItemIcon>
+          <Icon name="router" size="md" />
+        </ListItemIcon>
+        <ListItemText primary="Devices" />
+      </ListItemButton>
+
+      <ListItemButton
+        dense
         selected={currentPath.includes('/admin/admins')}
         onClick={() => handleNavClick('/admin/admins')}
       >

--- a/frontend/src/models/adminDevices.ts
+++ b/frontend/src/models/adminDevices.ts
@@ -1,0 +1,148 @@
+import { createModel } from '@rematch/core'
+import type { RootModel } from '.'
+import { graphQLAdminDevices } from '../services/graphQLRequest'
+
+export interface AdminDevice {
+  id: string
+  name?: string
+  state?: string
+  created?: string
+  owner?: {
+    id?: string
+    email?: string
+  }
+  [key: string]: any
+}
+
+// 'name' is an index-fast prefix match, 'contains' is the full substring search (slower,
+// server scans every device name), 'deviceId' matches device/hardware address exact or
+// prefix, 'email' scopes to an owner, 'all' lets the server route the term.
+export type AdminDeviceSearchType = 'all' | 'name' | 'contains' | 'deviceId' | 'email'
+
+interface AdminDevicesState {
+  devices: AdminDevice[]
+  total: number
+  hasMore: boolean
+  loading: boolean
+  page: number
+  pageSize: number
+  searchValue: string
+  searchType: AdminDeviceSearchType
+}
+
+const initialState: AdminDevicesState = {
+  devices: [],
+  total: 0,
+  hasMore: false,
+  loading: false,
+  page: 1,
+  pageSize: 50,
+  searchValue: '',
+  searchType: 'name',
+}
+
+function searchFilters(searchValue: string, searchType: AdminDeviceSearchType) {
+  const trimmed = searchValue.trim()
+  if (!trimmed) return undefined
+
+  switch (searchType) {
+    case 'name':
+      return { name: trimmed }
+    case 'contains':
+      return { nameContains: trimmed }
+    case 'deviceId':
+      return { deviceId: trimmed }
+    case 'email':
+      return { email: trimmed }
+    case 'all':
+    default:
+      return { search: trimmed }
+  }
+}
+
+export const adminDevices = createModel<RootModel>()({
+  name: 'adminDevices',
+  state: initialState,
+  reducers: {
+    setDevices: (state, payload: { devices: AdminDevice[]; total: number; hasMore: boolean }) => ({
+      ...state,
+      devices: payload.devices,
+      total: payload.total,
+      hasMore: payload.hasMore,
+      loading: false,
+    }),
+    appendDevices: (state, payload: { devices: AdminDevice[]; total: number; hasMore: boolean }) => ({
+      ...state,
+      devices: [...state.devices, ...payload.devices],
+      total: payload.total,
+      hasMore: payload.hasMore,
+      loading: false,
+    }),
+    setLoading: (state, loading: boolean) => ({
+      ...state,
+      loading,
+    }),
+    setPage: (state, page: number) => ({
+      ...state,
+      page,
+    }),
+    setSearch: (state, payload: { searchValue: string; searchType: AdminDeviceSearchType }) => ({
+      ...state,
+      searchValue: payload.searchValue,
+      searchType: payload.searchType,
+      page: 1, // Reset to first page on new search
+    }),
+    reset: () => initialState,
+  },
+  effects: dispatch => ({
+    async fetch(_: void, rootState) {
+      const state = rootState.adminDevices
+      dispatch.adminDevices.setLoading(true)
+
+      const result = await graphQLAdminDevices(
+        { from: (state.page - 1) * state.pageSize, size: state.pageSize },
+        searchFilters(state.searchValue, state.searchType),
+        'name'
+      )
+
+      if (result !== 'ERROR' && result?.data?.data?.admin?.devices) {
+        const data = result.data.data.admin.devices
+        dispatch.adminDevices.setDevices({
+          devices: data.items || [],
+          total: data.total || 0,
+          hasMore: !!data.hasMore,
+        })
+      } else {
+        dispatch.adminDevices.setLoading(false)
+      }
+    },
+    async fetchMore(_: void, rootState) {
+      const state = rootState.adminDevices
+      if (!state.hasMore || state.loading) return
+
+      dispatch.adminDevices.setLoading(true)
+
+      const result = await graphQLAdminDevices(
+        { from: state.devices.length, size: state.pageSize },
+        searchFilters(state.searchValue, state.searchType),
+        'name'
+      )
+
+      if (result !== 'ERROR' && result?.data?.data?.admin?.devices) {
+        const data = result.data.data.admin.devices
+        dispatch.adminDevices.appendDevices({
+          devices: data.items || [],
+          total: data.total || 0,
+          hasMore: !!data.hasMore,
+        })
+      } else {
+        dispatch.adminDevices.setLoading(false)
+      }
+    },
+    async fetchIfEmpty(_: void, rootState) {
+      if (rootState.adminDevices.devices.length === 0) {
+        await dispatch.adminDevices.fetch(undefined)
+      }
+    },
+  }),
+})

--- a/frontend/src/models/index.ts
+++ b/frontend/src/models/index.ts
@@ -1,5 +1,6 @@
 import { Models } from '@rematch/core'
 import accounts from './accounts'
+import { adminDevices } from './adminDevices'
 import agents from './agents'
 import { adminPartners } from './adminPartners'
 import { adminUsers } from './adminUsers'
@@ -36,6 +37,7 @@ import user from './user'
 
 export interface RootModel extends Models<RootModel> {
   accounts: typeof accounts
+  adminDevices: typeof adminDevices
   agents: typeof agents
   adminPartners: typeof adminPartners
   adminUsers: typeof adminUsers
@@ -73,6 +75,7 @@ export interface RootModel extends Models<RootModel> {
 
 export const models: RootModel = {
   accounts,
+  adminDevices,
   agents,
   adminPartners,
   adminUsers,

--- a/frontend/src/pages/AdminDevicesPage/AdminDeviceListItem.tsx
+++ b/frontend/src/pages/AdminDevicesPage/AdminDeviceListItem.tsx
@@ -1,0 +1,44 @@
+import { Box } from '@mui/material'
+import { makeStyles } from '@mui/styles'
+import React from 'react'
+import { GridListItem } from '../../components/GridListItem'
+import { Icon } from '../../components/Icon'
+import { AdminDevice } from '../../models/adminDevices'
+import { AdminDeviceAttribute } from './adminDeviceAttributes'
+
+interface Props {
+  device: AdminDevice
+  required?: AdminDeviceAttribute
+  attributes: AdminDeviceAttribute[]
+  onClick: () => void
+}
+
+export const AdminDeviceListItem: React.FC<Props> = ({ device, required, attributes, onClick }) => {
+  const css = useStyles()
+  const active = device.state === 'active'
+
+  return (
+    <GridListItem
+      onClick={onClick}
+      disableGutters
+      icon={<Icon name="router" size="md" color={active ? 'primary' : 'grayDark'} />}
+      required={required?.value({ device })}
+    >
+      {attributes.map(attribute => (
+        <Box key={attribute.id} className="attribute">
+          <div className={css.truncate}>{attribute.value({ device })}</div>
+        </Box>
+      ))}
+    </GridListItem>
+  )
+}
+
+const useStyles = makeStyles(() => ({
+  truncate: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    minWidth: 0,
+    flex: 1,
+  },
+}))

--- a/frontend/src/pages/AdminDevicesPage/AdminDevicesListPage.tsx
+++ b/frontend/src/pages/AdminDevicesPage/AdminDevicesListPage.tsx
@@ -1,0 +1,165 @@
+import { Box, Button, Stack, TextField, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material'
+import React, { useEffect, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { useHistory } from 'react-router-dom'
+import { Container } from '../../components/Container'
+import { GridList } from '../../components/GridList'
+import { Gutters } from '../../components/Gutters'
+import { Icon } from '../../components/Icon'
+import { LoadingMessage } from '../../components/LoadingMessage'
+import { removeObject } from '../../helpers/utilHelper'
+import { AdminDeviceSearchType } from '../../models/adminDevices'
+import { Dispatch, State } from '../../store'
+import { AdminDeviceListItem } from './AdminDeviceListItem'
+import { adminDeviceAttributes } from './adminDeviceAttributes'
+
+export const AdminDevicesListPage: React.FC = () => {
+  const history = useHistory()
+  const dispatch = useDispatch<Dispatch>()
+  const [searchInput, setSearchInput] = useState('')
+  const columnWidths = useSelector((state: State) => state.ui.columnWidths)
+  const [required, attributes] = removeObject(adminDeviceAttributes, a => a.required === true)
+
+  const devices = useSelector((state: State) => state.adminDevices.devices)
+  const total = useSelector((state: State) => state.adminDevices.total)
+  const loading = useSelector((state: State) => state.adminDevices.loading)
+  const hasMore = useSelector((state: State) => state.adminDevices.hasMore)
+  const page = useSelector((state: State) => state.adminDevices.page)
+  const searchValue = useSelector((state: State) => state.adminDevices.searchValue)
+  const searchType = useSelector((state: State) => state.adminDevices.searchType)
+  const searching = !!searchValue.trim()
+
+  // Initialize search input from Redux state
+  useEffect(() => {
+    setSearchInput(searchValue)
+  }, [])
+
+  // Fetch on mount if empty
+  useEffect(() => {
+    dispatch.adminDevices.fetchIfEmpty(undefined)
+  }, [])
+
+  // Fetch when page/search changes (but not on initial mount)
+  const isInitialMount = React.useRef(true)
+  useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false
+      return
+    }
+    dispatch.adminDevices.fetch(undefined)
+  }, [page, searchValue, searchType])
+
+  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchInput(event.target.value)
+  }
+
+  const handleSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      dispatch.adminDevices.setSearch({ searchValue: searchInput, searchType })
+    }
+  }
+
+  const handleSearchTypeChange = (_: React.MouseEvent<HTMLElement>, newType: AdminDeviceSearchType | null) => {
+    if (newType !== null) {
+      dispatch.adminDevices.setSearch({ searchValue: searchInput, searchType: newType })
+    }
+  }
+
+  const getPlaceholder = () => {
+    switch (searchType) {
+      case 'name':
+        return 'Search by name prefix (fast)...'
+      case 'contains':
+        return 'Search names containing (full search, slower)...'
+      case 'deviceId':
+        return 'Search by device or hardware ID, exact or prefix...'
+      case 'email':
+        return 'Search by owner email...'
+      case 'all':
+      default:
+        return 'Search by name, device ID, or owner email...'
+    }
+  }
+
+  const handleDeviceClick = (ownerId?: string) => {
+    if (!ownerId) return
+    const route = `/admin/users/${ownerId}`
+    dispatch.ui.setDefaultSelected({ key: '/admin/users', value: route, accountId: 'admin' })
+    history.push(route)
+  }
+
+  return (
+    <Container
+      integrated
+      gutterBottom
+      bodyProps={{ verticalOverflow: true, horizontalOverflow: true }}
+      header={
+        <Gutters>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <ToggleButtonGroup value={searchType} exclusive onChange={handleSearchTypeChange} size="small">
+              <ToggleButton value="name" title="Name prefix — fast">
+                Name
+              </ToggleButton>
+              <ToggleButton value="contains" title="Name contains — full search, slower">
+                Contains
+              </ToggleButton>
+              <ToggleButton value="deviceId" title="Device or hardware ID, exact or prefix">
+                ID
+              </ToggleButton>
+              <ToggleButton value="email" title="Owner email">
+                Owner
+              </ToggleButton>
+              <ToggleButton value="all" title="Search all fields">
+                <Icon name="search" size="sm" />
+              </ToggleButton>
+            </ToggleButtonGroup>
+            <TextField
+              fullWidth
+              placeholder={getPlaceholder()}
+              value={searchInput}
+              onChange={handleSearchChange}
+              onKeyDown={handleSearchKeyDown}
+              size="small"
+              InputProps={{
+                startAdornment: <Icon name="search" size="sm" color="grayDark" inlineLeft />,
+              }}
+            />
+            <Typography variant="caption" color="textSecondary" sx={{ whiteSpace: 'nowrap' }}>
+              {searching ? `${devices.length}${hasMore ? '+' : ''} found` : `${total.toLocaleString()} devices`}
+            </Typography>
+          </Stack>
+        </Gutters>
+      }
+    >
+      {loading && devices.length === 0 ? (
+        <LoadingMessage message="Loading devices..." />
+      ) : devices.length === 0 ? (
+        <Box sx={{ textAlign: 'center', padding: 4 }}>
+          <Icon name="router" size="xxl" color="grayLight" />
+          <Typography variant="h2" gutterBottom sx={{ marginTop: 2 }}>
+            No devices found
+          </Typography>
+        </Box>
+      ) : (
+        <GridList attributes={attributes} required={required} columnWidths={columnWidths} fetching={loading}>
+          {devices.map(device => (
+            <AdminDeviceListItem
+              key={device.id}
+              device={device}
+              required={required}
+              attributes={attributes}
+              onClick={() => handleDeviceClick(device.owner?.id)}
+            />
+          ))}
+          {hasMore && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+              <Button color="primary" disabled={loading} onClick={() => dispatch.adminDevices.fetchMore(undefined)}>
+                {loading ? 'Loading...' : 'Load More'}
+              </Button>
+            </Box>
+          )}
+        </GridList>
+      )}
+    </Container>
+  )
+}

--- a/frontend/src/pages/AdminDevicesPage/adminDeviceAttributes.tsx
+++ b/frontend/src/pages/AdminDevicesPage/adminDeviceAttributes.tsx
@@ -1,0 +1,45 @@
+import { Attribute } from '../../components/Attributes'
+import { AdminDevice } from '../../models/adminDevices'
+
+export type AdminDeviceAttributeOptions = {
+  device?: AdminDevice
+}
+
+export class AdminDeviceAttribute extends Attribute<AdminDeviceAttributeOptions> {
+  type: Attribute['type'] = 'MASTER'
+}
+
+export const adminDeviceAttributes: AdminDeviceAttribute[] = [
+  new AdminDeviceAttribute({
+    id: 'deviceName',
+    label: 'Name',
+    defaultWidth: 250,
+    required: true,
+    value: ({ device }: AdminDeviceAttributeOptions) => device?.name || '-',
+  }),
+  new AdminDeviceAttribute({
+    id: 'deviceState',
+    label: 'State',
+    defaultWidth: 100,
+    value: ({ device }: AdminDeviceAttributeOptions) => device?.state || '-',
+  }),
+  new AdminDeviceAttribute({
+    id: 'deviceOwner',
+    label: 'Owner',
+    defaultWidth: 250,
+    value: ({ device }: AdminDeviceAttributeOptions) => device?.owner?.email || '-',
+  }),
+  new AdminDeviceAttribute({
+    id: 'deviceId',
+    label: 'Device ID',
+    defaultWidth: 320,
+    value: ({ device }: AdminDeviceAttributeOptions) => device?.id,
+  }),
+  new AdminDeviceAttribute({
+    id: 'deviceCreated',
+    label: 'Created',
+    defaultWidth: 150,
+    value: ({ device }: AdminDeviceAttributeOptions) =>
+      device?.created ? new Date(device.created).toLocaleDateString() : '-',
+  }),
+]

--- a/frontend/src/routers/Router.tsx
+++ b/frontend/src/routers/Router.tsx
@@ -58,6 +58,7 @@ import { ConnectedAppsPage } from '../pages/ConnectedAppsPage'
 import { ConnectedAppDetailPage } from '../pages/ConnectedAppDetailPage'
 import { NotificationsPage } from '../pages/NotificationsPage'
 import { AdminUsersWithDetailPage } from '../pages/AdminUsersPage/AdminUsersWithDetailPage'
+import { AdminDevicesListPage } from '../pages/AdminDevicesPage/AdminDevicesListPage'
 import { AdminConfirmPage } from '../pages/AdminConfirmPage'
 import { AdminAdminsPage } from '../pages/AdminAdminsPage/AdminAdminsPage'
 import { AdminPartnersPage } from '../pages/AdminPartnersPage/AdminPartnersPage'
@@ -434,6 +435,9 @@ export const Router: React.FC<{ layout: ILayout }> = ({ layout }) => {
               </Route>
               <Route path="/admin/notices/:noticeId?">
                 <AdminNoticesPage />
+              </Route>
+              <Route path="/admin/devices">
+                <AdminDevicesListPage />
               </Route>
               <Redirect to="/admin/users" />
             </Switch>

--- a/frontend/src/services/graphQLRequest.ts
+++ b/frontend/src/services/graphQLRequest.ts
@@ -989,3 +989,50 @@ export async function graphQLAllNotices() {
       }`
   )
 }
+
+export async function graphQLAdminDevices(
+  options: { from?: number; size?: number },
+  filters?: {
+    search?: string
+    name?: string
+    nameContains?: string
+    deviceId?: string
+    email?: string
+    accountId?: string
+    hardwareId?: string
+  },
+  sort?: string
+) {
+  return await graphQLBasicRequest(
+    ` query AdminDevices($from: Int, $size: Int, $search: String, $name: String, $nameContains: String, $deviceId: String, $email: String, $accountId: String, $hardwareId: String, $sort: String) {
+        admin {
+          devices(from: $from, size: $size, search: $search, name: $name, nameContains: $nameContains, deviceId: $deviceId, email: $email, accountId: $accountId, hardwareId: $hardwareId, sort: $sort) {
+            items {
+              id
+              name
+              state
+              created
+              owner {
+                id
+                email
+              }
+            }
+            total
+            hasMore
+          }
+        }
+      }`,
+    {
+      from: options.from,
+      size: options.size,
+      search: filters?.search,
+      name: filters?.name,
+      nameContains: filters?.nameContains,
+      deviceId: filters?.deviceId,
+      email: filters?.email,
+      accountId: filters?.accountId,
+      hardwareId: filters?.hardwareId,
+      sort,
+    }
+  )
+}


### PR DESCRIPTION
Adds a system-wide **Devices** page to the Admin section at `/admin/devices`, backed by the new `admin.devices` query (remoteit/graphql-api#188, #189).

Follows the AdminUsersPage patterns: `adminDevices` Rematch model, GridList columns (name / state / owner / device id / created), Load More pagination, and Enter-to-search with a search-type toggle — **Name** (prefix, index-fast), **Contains** (full substring), **ID** (device or hardware address, exact or prefix), **Owner** (email), and a generic mode the server routes (address → id/hardware, `@` → owner, otherwise name with automatic prefix→contains fallback, so serial fragments like `0389J512YU` just work). Unfiltered loads show the exact system total (~1.23M); searches show "N+ found" from the server's hasMore estimate. Row click jumps to the owner's admin user page.

Rebased over the notices + i18n work; verified against the evan stage (searches 0.4–1.6s end-to-end, deep pages ~1.3s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
