### PR TITLE
fix: migrate AdminDeviceListItem off the removed @mui/styles

### DIFF
--- a/frontend/src/pages/AdminDevicesPage/AdminDeviceListItem.tsx
+++ b/frontend/src/pages/AdminDevicesPage/AdminDeviceListItem.tsx
@@ -1,5 +1,4 @@
 import { Box } from '@mui/material'
-import { makeStyles } from '@mui/styles'
 import React from 'react'
 import { GridListItem } from '../../components/GridListItem'
 import { Icon } from '../../components/Icon'
@@ -14,7 +13,6 @@ interface Props {
 }
 
 export const AdminDeviceListItem: React.FC<Props> = ({ device, required, attributes, onClick }) => {
-  const css = useStyles()
   const active = device.state === 'active'
 
   return (
@@ -26,19 +24,11 @@ export const AdminDeviceListItem: React.FC<Props> = ({ device, required, attribu
     >
       {attributes.map(attribute => (
         <Box key={attribute.id} className="attribute">
-          <div className={css.truncate}>{attribute.value({ device })}</div>
+          <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0, flex: 1 }}>
+            {attribute.value({ device })}
+          </Box>
         </Box>
       ))}
     </GridListItem>
   )
 }
-
-const useStyles = makeStyles(() => ({
-  truncate: {
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-    minWidth: 0,
-    flex: 1,
-  },
-}))


### PR DESCRIPTION
Follow-up to #1162: the i18n/MUI-cleanup wave removed `@mui/styles`, and the new AdminDeviceListItem (written against the pre-migration template) was the only remaining importer — a fresh `npm install` fails to resolve it. Migrated to the same `sx` pattern as AdminUserListItem; frontend typechecks clean (0 errors) on a fresh dependency tree and the app boots verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)