### PR TITLE
feat: device detail page in the Admin Devices section

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -44,7 +44,7 @@ export const Header: React.FC<Props> = ({ panels = 1 }) => {
   const menu = location.pathname.match(REGEX_FIRST_PATH)?.[0]
 
   // Admin pages have two-level roots: /admin/users and /admin/partners (without IDs)
-  const adminRootPages = ['/admin/users', '/admin/admins', '/admin/partners', '/admin/enterprise-licenses', '/partner-stats']
+  const adminRootPages = ['/admin/users', '/admin/admins', '/admin/partners', '/admin/enterprise-licenses', '/admin/devices', '/admin/notices', '/partner-stats']
   const isAdminRootPage = adminRootPages.includes(location.pathname)
   const isRootMenu = menu === location.pathname || isAdminRootPage
 

--- a/frontend/src/models/adminDevices.ts
+++ b/frontend/src/models/adminDevices.ts
@@ -1,6 +1,6 @@
 import { createModel } from '@rematch/core'
 import type { RootModel } from '.'
-import { graphQLAdminDevices } from '../services/graphQLRequest'
+import { graphQLAdminDevice, graphQLAdminDevices } from '../services/graphQLRequest'
 
 export interface AdminDevice {
   id: string
@@ -28,6 +28,7 @@ interface AdminDevicesState {
   pageSize: number
   searchValue: string
   searchType: AdminDeviceSearchType
+  detailCache: { [deviceId: string]: AdminDevice }
 }
 
 const initialState: AdminDevicesState = {
@@ -39,6 +40,7 @@ const initialState: AdminDevicesState = {
   pageSize: 50,
   searchValue: '',
   searchType: 'name',
+  detailCache: {},
 }
 
 function searchFilters(searchValue: string, searchType: AdminDeviceSearchType) {
@@ -92,6 +94,18 @@ export const adminDevices = createModel<RootModel>()({
       searchType: payload.searchType,
       page: 1, // Reset to first page on new search
     }),
+    cacheDeviceDetail: (state, payload: { deviceId: string; device: AdminDevice }) => {
+      // Merge so the sparse list row (name/state/owner) doesn't clobber detail-only fields
+      // already cached (services, endpoint, access, ...).
+      const existing = state.detailCache[payload.deviceId]
+      return {
+        ...state,
+        detailCache: {
+          ...state.detailCache,
+          [payload.deviceId]: existing ? { ...existing, ...payload.device } : payload.device,
+        },
+      }
+    },
     reset: () => initialState,
   },
   effects: dispatch => ({
@@ -143,6 +157,23 @@ export const adminDevices = createModel<RootModel>()({
       if (rootState.adminDevices.devices.length === 0) {
         await dispatch.adminDevices.fetch(undefined)
       }
+    },
+    async fetchDeviceDetail(payload: string | { deviceId: string; force?: boolean }, rootState) {
+      const { deviceId, force } = typeof payload === 'string' ? { deviceId: payload, force: false } : payload
+
+      // Serve from cache unless a forced refresh is requested; on force we keep the existing
+      // entry visible and overwrite it when fresh data lands (cacheDeviceDetail merges).
+      const cached = rootState.adminDevices.detailCache[deviceId]
+      if (cached?.services && !force) return cached
+
+      const result = await graphQLAdminDevice(deviceId)
+      const device = result !== 'ERROR' ? result?.data?.data?.admin?.devices?.items?.[0] : undefined
+
+      if (device) {
+        dispatch.adminDevices.cacheDeviceDetail({ deviceId, device })
+        return device
+      }
+      return cached || null
     },
   }),
 })

--- a/frontend/src/pages/AdminDevicesPage/AdminDeviceDetailPage.tsx
+++ b/frontend/src/pages/AdminDevicesPage/AdminDeviceDetailPage.tsx
@@ -1,0 +1,204 @@
+import { Box, Divider, List, ListItem, ListItemButton, ListItemText, Typography } from '@mui/material'
+import React, { useEffect, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { useHistory, useParams } from 'react-router-dom'
+import { CopyIconButton } from '../../buttons/CopyIconButton'
+import { Body } from '../../components/Body'
+import { Container } from '../../components/Container'
+import { Icon } from '../../components/Icon'
+import { LoadingMessage } from '../../components/LoadingMessage'
+import { StatusChip } from '../../components/StatusChip'
+import { TargetPlatform } from '../../components/TargetPlatform/TargetPlatform'
+import { Timestamp } from '../../components/Timestamp'
+import { Title } from '../../components/Title'
+import { AdminDevice } from '../../models/adminDevices'
+import { Dispatch, State } from '../../store'
+
+const Mono: React.FC<{ value?: string; copy?: boolean }> = ({ value, copy }) => {
+  if (!value) return <>—</>
+  return (
+    <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 1 }}>
+      <Typography variant="body2" component="span" sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>
+        {value}
+      </Typography>
+      {copy && <CopyIconButton value={value} size="sm" />}
+    </Box>
+  )
+}
+
+const Row: React.FC<{ label: string; children?: React.ReactNode }> = ({ label, children }) => (
+  <>
+    <ListItem>
+      <ListItemText primary={label} secondary={children ?? '—'} secondaryTypographyProps={{ component: 'div' }} />
+    </ListItem>
+    <Divider component="li" />
+  </>
+)
+
+const when = (value?: string) => (value ? <Timestamp date={new Date(value)} /> : undefined)
+
+export const AdminDeviceDetailPage: React.FC = () => {
+  const { deviceId = '' } = useParams<{ deviceId?: string }>()
+  const history = useHistory()
+  const dispatch = useDispatch<Dispatch>()
+  const device: AdminDevice | undefined = useSelector((state: State) => state.adminDevices.detailCache[deviceId])
+  const [loading, setLoading] = useState(!device)
+
+  useEffect(() => {
+    if (!deviceId) return
+    let active = true
+    setLoading(true)
+    dispatch.adminDevices.fetchDeviceDetail(deviceId).finally(() => active && setLoading(false))
+    return () => {
+      active = false
+    }
+  }, [deviceId])
+
+  if (loading && !device) {
+    return (
+      <Container gutterBottom>
+        <LoadingMessage message="Loading device..." />
+      </Container>
+    )
+  }
+
+  if (!device) {
+    return (
+      <Container gutterBottom>
+        <Body center>
+          <Icon name="exclamation-triangle" size="xxl" color="warning" />
+          <Typography variant="h2" gutterBottom sx={{ marginTop: 2 }}>
+            Device not found
+          </Typography>
+        </Body>
+      </Container>
+    )
+  }
+
+  const services = (device.services as IService[]) || []
+  const shared = (device.access as { user?: { id?: string; email?: string } }[]) || []
+  const geo = device.endpoint?.geo
+
+  const handleOwnerClick = () => {
+    const ownerId = device.owner?.id
+    if (!ownerId) return
+    const route = `/admin/users/${ownerId}`
+    dispatch.ui.setDefaultSelected({ key: '/admin/users', value: route, accountId: 'admin' })
+    history.push(route)
+  }
+
+  return (
+    <Container
+      gutterBottom
+      bodyProps={{ verticalOverflow: true }}
+      header={
+        <Box sx={{ padding: 2 }}>
+          <Typography variant="h2">
+            <Title>{device.name || device.id}</Title>
+          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, marginTop: 1 }}>
+            <StatusChip device={{ state: device.state, services } as IDevice} />
+            <TargetPlatform id={device.platform} size="md" label />
+          </Box>
+        </Box>
+      }
+    >
+      <List disablePadding>
+        <Row label="Owner">
+          {device.owner?.id ? (
+            <ListItemButton
+              dense
+              disableGutters
+              onClick={handleOwnerClick}
+              sx={{ paddingY: 0, borderRadius: 1, width: 'fit-content' }}
+            >
+              <Icon name="user" size="sm" color="grayDark" inlineLeft />
+              <Typography variant="body2" component="span" color="primary">
+                {device.owner.email || device.owner.id}
+              </Typography>
+              <Icon name="chevron-right" size="sm" color="grayDark" inlineLeft />
+            </ListItemButton>
+          ) : undefined}
+        </Row>
+        <Row label="Device ID">
+          <Mono value={device.id} copy />
+        </Row>
+        <Row label="Hardware ID">
+          <Mono value={device.hardwareId} copy />
+        </Row>
+        <Row label="Version">{device.version}</Row>
+        <Row label="License">{device.license}</Row>
+        <Row label="Created">{when(device.created)}</Row>
+        <Row label="Last reported">{when(device.lastReported)}</Row>
+        <Row label="Capabilities">
+          {[device.configurable && 'configurable', device.scriptable && 'scriptable'].filter(Boolean).join(' • ') ||
+            undefined}
+        </Row>
+        <Row label="External address">
+          <Mono value={device.endpoint?.externalAddress} />
+        </Row>
+        <Row label="Internal address">
+          <Mono value={device.endpoint?.internalAddress} />
+        </Row>
+        <Row label="Location">
+          {geo ? [geo.city, geo.stateName, geo.countryName].filter(Boolean).join(', ') || undefined : undefined}
+        </Row>
+        <Row label="ISP">{geo?.isp}</Row>
+        <Row label="Quality">
+          {device.endpoint?.quality != null ? `${device.endpoint.quality}` : undefined}
+        </Row>
+      </List>
+
+      <Typography variant="subtitle1" sx={{ marginTop: 2 }}>
+        <Title>Services ({services.length})</Title>
+      </Typography>
+      <List disablePadding>
+        {services.length ? (
+          services.map(service => (
+            <React.Fragment key={service.id}>
+              <ListItem>
+                <ListItemText
+                  primary={service.name || service.id}
+                  secondary={
+                    <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 1 }}>
+                      <StatusChip service={service} />
+                      <Typography variant="body2" component="span" sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>
+                        {service.id}
+                      </Typography>
+                    </Box>
+                  }
+                  secondaryTypographyProps={{ component: 'div' }}
+                />
+              </ListItem>
+              <Divider component="li" />
+            </React.Fragment>
+          ))
+        ) : (
+          <ListItem>
+            <ListItemText secondary="No services" />
+          </ListItem>
+        )}
+      </List>
+
+      <Typography variant="subtitle1" sx={{ marginTop: 2 }}>
+        <Title>Shared with ({shared.length})</Title>
+      </Typography>
+      <List disablePadding>
+        {shared.length ? (
+          shared.map((item, index) => (
+            <React.Fragment key={item.user?.id || index}>
+              <ListItem>
+                <ListItemText primary={item.user?.email || item.user?.id} />
+              </ListItem>
+              <Divider component="li" />
+            </React.Fragment>
+          ))
+        ) : (
+          <ListItem>
+            <ListItemText secondary="Not shared" />
+          </ListItem>
+        )}
+      </List>
+    </Container>
+  )
+}

--- a/frontend/src/pages/AdminDevicesPage/AdminDeviceListItem.tsx
+++ b/frontend/src/pages/AdminDevicesPage/AdminDeviceListItem.tsx
@@ -9,17 +9,19 @@ interface Props {
   device: AdminDevice
   required?: AdminDeviceAttribute
   attributes: AdminDeviceAttribute[]
+  active?: boolean
   onClick: () => void
 }
 
-export const AdminDeviceListItem: React.FC<Props> = ({ device, required, attributes, onClick }) => {
-  const active = device.state === 'active'
+export const AdminDeviceListItem: React.FC<Props> = ({ device, required, attributes, active, onClick }) => {
+  const online = device.state === 'active'
 
   return (
     <GridListItem
       onClick={onClick}
+      selected={active}
       disableGutters
-      icon={<Icon name="router" size="md" color={active ? 'primary' : 'grayDark'} />}
+      icon={<Icon name="router" size="md" color={online ? 'primary' : 'grayDark'} />}
       required={required?.value({ device })}
     >
       {attributes.map(attribute => (

--- a/frontend/src/pages/AdminDevicesPage/AdminDevicesListPage.tsx
+++ b/frontend/src/pages/AdminDevicesPage/AdminDevicesListPage.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, Stack, TextField, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material'
 import React, { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { useHistory } from 'react-router-dom'
+import { useHistory, useLocation } from 'react-router-dom'
 import { Container } from '../../components/Container'
 import { GridList } from '../../components/GridList'
 import { Gutters } from '../../components/Gutters'
@@ -15,6 +15,7 @@ import { adminDeviceAttributes } from './adminDeviceAttributes'
 
 export const AdminDevicesListPage: React.FC = () => {
   const history = useHistory()
+  const location = useLocation()
   const dispatch = useDispatch<Dispatch>()
   const [searchInput, setSearchInput] = useState('')
   const columnWidths = useSelector((state: State) => state.ui.columnWidths)
@@ -81,10 +82,9 @@ export const AdminDevicesListPage: React.FC = () => {
     }
   }
 
-  const handleDeviceClick = (ownerId?: string) => {
-    if (!ownerId) return
-    const route = `/admin/users/${ownerId}`
-    dispatch.ui.setDefaultSelected({ key: '/admin/users', value: route, accountId: 'admin' })
+  const handleDeviceClick = (deviceId: string) => {
+    const route = `/admin/devices/${deviceId}`
+    dispatch.ui.setDefaultSelected({ key: '/admin/devices', value: route, accountId: 'admin' })
     history.push(route)
   }
 
@@ -148,7 +148,8 @@ export const AdminDevicesListPage: React.FC = () => {
               device={device}
               required={required}
               attributes={attributes}
-              onClick={() => handleDeviceClick(device.owner?.id)}
+              active={location.pathname.includes(`/admin/devices/${device.id}`)}
+              onClick={() => handleDeviceClick(device.id)}
             />
           ))}
           {hasMore && (

--- a/frontend/src/pages/AdminDevicesPage/AdminDevicesWithDetailPage.tsx
+++ b/frontend/src/pages/AdminDevicesPage/AdminDevicesWithDetailPage.tsx
@@ -1,0 +1,115 @@
+import { Box } from '@mui/material'
+import React, { useEffect, useRef } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { useHistory, useLocation, useParams } from 'react-router-dom'
+import { useContainerWidth } from '../../hooks/useContainerWidth'
+import { useResizablePanel } from '../../hooks/useResizablePanel'
+import { Dispatch, State } from '../../store'
+import { AdminDeviceDetailPage } from './AdminDeviceDetailPage'
+import { AdminDevicesListPage } from './AdminDevicesListPage'
+
+const MIN_WIDTH = 250
+const DEFAULT_LEFT_WIDTH = 400
+
+const panelSx = {
+  height: '100%',
+  overflow: 'hidden',
+  display: 'flex',
+  flexDirection: 'column',
+  flexShrink: 0,
+} as const
+
+const handleSx = (theme: import('@mui/material').Theme) => ({
+  zIndex: 8,
+  position: 'absolute',
+  height: '100%',
+  marginLeft: '-5px',
+  padding: '0 3px',
+  cursor: 'col-resize',
+  '& > div': {
+    width: '1px',
+    marginLeft: '1px',
+    marginRight: '1px',
+    height: '100%',
+    backgroundColor: theme.palette.grayLighter.main,
+    transition: 'background-color 100ms 200ms, width 100ms 200ms, margin 100ms 200ms',
+  },
+  '&:hover > div, & .active': {
+    width: '3px',
+    marginLeft: 0,
+    marginRight: 0,
+    backgroundColor: theme.palette.primary.main,
+  },
+})
+
+export const AdminDevicesWithDetailPage: React.FC = () => {
+  const { deviceId } = useParams<{ deviceId?: string }>()
+  const history = useHistory()
+  const location = useLocation()
+  const dispatch = useDispatch<Dispatch>()
+  const layout = useSelector((state: State) => state.ui.layout)
+  const defaultSelection = useSelector((state: State) => state.ui.defaultSelection)
+  const hasRestoredRef = useRef(false)
+
+  const { containerRef, containerWidth } = useContainerWidth()
+  const leftPanel = useResizablePanel(DEFAULT_LEFT_WIDTH, containerRef, { minWidth: MIN_WIDTH })
+
+  // Below two panels' worth of width the detail takes over the whole area.
+  const twoPanel = !layout.singlePanel && containerWidth >= MIN_WIDTH * 2
+
+  // Restore the previously selected device ONLY on initial mount
+  useEffect(() => {
+    if (!hasRestoredRef.current) {
+      const savedRoute = defaultSelection['admin']?.['/admin/devices']
+      if (location.pathname === '/admin/devices' && savedRoute) history.replace(savedRoute)
+      hasRestoredRef.current = true
+    }
+  }, [])
+
+  // Persist explicit navigation back to the device list
+  useEffect(() => {
+    if (location.pathname === '/admin/devices') {
+      dispatch.ui.setDefaultSelected({ key: '/admin/devices', value: '/admin/devices', accountId: 'admin' })
+    }
+  }, [location.pathname, dispatch])
+
+  const selected = !!deviceId
+  const showList = !selected || twoPanel
+  const showDetail = selected
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', width: '100%' }} ref={containerRef}>
+      <Box sx={{ display: 'flex', flexDirection: 'row', flex: 1, overflow: 'hidden' }}>
+        {showList && (
+          <>
+            <Box
+              sx={panelSx}
+              style={{
+                width: selected ? leftPanel.width : undefined,
+                minWidth: selected ? leftPanel.width : undefined,
+                flex: selected ? undefined : 1,
+              }}
+              ref={leftPanel.panelRef}
+            >
+              <AdminDevicesListPage />
+            </Box>
+
+            {selected && (
+              <Box sx={{ position: 'relative', height: '100%' }}>
+                <Box sx={handleSx} onMouseDown={leftPanel.onDown}>
+                  <Box className={leftPanel.grab ? 'active' : undefined} />
+                </Box>
+              </Box>
+            )}
+          </>
+        )}
+
+        {showDetail && (
+          <Box sx={[panelSx, { flex: 1, minWidth: MIN_WIDTH }]}>
+            <AdminDeviceDetailPage />
+          </Box>
+        )}
+      </Box>
+    </Box>
+  )
+}

--- a/frontend/src/pages/AdminDevicesPage/adminDeviceAttributes.tsx
+++ b/frontend/src/pages/AdminDevicesPage/adminDeviceAttributes.tsx
@@ -7,6 +7,7 @@ export type AdminDeviceAttributeOptions = {
 
 export class AdminDeviceAttribute extends Attribute<AdminDeviceAttributeOptions> {
   type: Attribute['type'] = 'MASTER'
+  translate = false // internal-only admin registry: render English, skip columns.* translation
 }
 
 export const adminDeviceAttributes: AdminDeviceAttribute[] = [

--- a/frontend/src/routers/Router.tsx
+++ b/frontend/src/routers/Router.tsx
@@ -58,7 +58,7 @@ import { ConnectedAppsPage } from '../pages/ConnectedAppsPage'
 import { ConnectedAppDetailPage } from '../pages/ConnectedAppDetailPage'
 import { NotificationsPage } from '../pages/NotificationsPage'
 import { AdminUsersWithDetailPage } from '../pages/AdminUsersPage/AdminUsersWithDetailPage'
-import { AdminDevicesListPage } from '../pages/AdminDevicesPage/AdminDevicesListPage'
+import { AdminDevicesWithDetailPage } from '../pages/AdminDevicesPage/AdminDevicesWithDetailPage'
 import { AdminConfirmPage } from '../pages/AdminConfirmPage'
 import { AdminAdminsPage } from '../pages/AdminAdminsPage/AdminAdminsPage'
 import { AdminPartnersPage } from '../pages/AdminPartnersPage/AdminPartnersPage'
@@ -436,8 +436,8 @@ export const Router: React.FC<{ layout: ILayout }> = ({ layout }) => {
               <Route path="/admin/notices/:noticeId?">
                 <AdminNoticesPage />
               </Route>
-              <Route path="/admin/devices">
-                <AdminDevicesListPage />
+              <Route path="/admin/devices/:deviceId?">
+                <AdminDevicesWithDetailPage />
               </Route>
               <Redirect to="/admin/users" />
             </Switch>

--- a/frontend/src/routers/routeParents.ts
+++ b/frontend/src/routers/routeParents.ts
@@ -119,6 +119,7 @@ const ROUTE_PARENTS: [string, string][] = [
   ['/admin/users/:userId', '/admin/users'],
   ['/admin/partners/:partnerId', '/admin/partners'],
   ['/admin/notices/:noticeId', '/admin/notices'],
+  ['/admin/devices/:deviceId', '/admin/devices'],
 
   // Onboard
   ['/onboard/:platform/scanning', '/onboard/:platform'],
@@ -139,6 +140,10 @@ const ROUTE_PARENTS: [string, string][] = [
  * sections the left panel is a menu, so the parent list only exists in the
  * secondary panel — UP must follow ROUTE_PARENTS one level at a time.
  */
-export const MENU_SECTIONS = ['/account', '/organization', '/settings']
+// Sections whose left panel is a menu rather than the section's own list, so UP has to follow
+// the ROUTE_PARENTS map instead of falling back to the section root. /admin qualifies: its
+// sidebar is a menu and /admin redirects to /admin/users, so the fallback would land every
+// admin sub-page on the users list regardless of which page it came from.
+export const MENU_SECTIONS = ['/account', '/organization', '/settings', '/admin']
 
 export default ROUTE_PARENTS

--- a/frontend/src/services/graphQLRequest.ts
+++ b/frontend/src/services/graphQLRequest.ts
@@ -1036,3 +1036,64 @@ export async function graphQLAdminDevices(
     }
   )
 }
+
+export async function graphQLAdminDevice(deviceId: string) {
+  return await graphQLBasicRequest(
+    ` query AdminDevice($deviceId: String) {
+        admin {
+          devices(from: 0, size: 1, deviceId: $deviceId) {
+            items {
+              id
+              name
+              state
+              platform
+              version
+              hardwareId
+              license
+              created
+              lastReported
+              configurable
+              scriptable
+              owner {
+                id
+                email
+              }
+              endpoint {
+                externalAddress
+                internalAddress
+                availability
+                quality
+                onlineSince
+                offlineSince
+                geo {
+                  connectionType
+                  countryName
+                  stateName
+                  city
+                  isp
+                }
+              }
+              access {
+                user {
+                  id
+                  email
+                }
+                scripting
+              }
+              services {
+                id
+                name
+                state
+                port
+                type
+                application
+                license
+                lastReported
+              }
+            }
+          }
+        }
+      }`,
+    { deviceId }
+  )
+}


### PR DESCRIPTION
Follow-up to #1162: picking a device in the Admin Devices list now opens a **device detail page** at `/admin/devices/:deviceId` instead of jumping straight to the owner's admin user page. The owner is a row on that page — clicking it navigates to the user. So the device is the destination, and the user is one step away rather than the other way around.

**Layout** follows the AdminUsersPage split-panel pattern: resizable list + detail, with the detail taking the full area when there isn't room for two panels, and the same selection persistence (returning to Devices restores the last selected device).

**The detail page shows** what support actually needs: status, platform, owner (clickable), device + hardware ids (copyable), version, license, created / last reported, capabilities, external + internal addresses, geo/ISP, connection quality, the service list with per-service state, and who the device is shared with. Backed by a new `graphQLAdminDevice` query and a `detailCache` in the adminDevices model that merges over the sparse list row, mirroring `adminUsers`.

Also sets `translate = false` on `AdminDeviceAttribute`, matching the convention for internal-only admin registries (as `AdminUserDevicesPanel` already does).

Frontend typechecks clean (0 errors) and the app boots with no console/render errors; the page itself renders behind admin login, so a signed-in pass is worth doing before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
