### PR TITLE
fix: reconnect websockets after sign out, and refresh devices from the add pages

### DIFF
--- a/frontend/src/buttons/RefreshButton/RefreshButton.tsx
+++ b/frontend/src/buttons/RefreshButton/RefreshButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import network from '../../services/Network'
 import cloudController from '../../services/cloudController'
 import cloudSync from '../../services/CloudSync'
@@ -13,6 +14,7 @@ import { GuideBubble } from '../../components/GuideBubble'
 import { Typography } from '@mui/material'
 
 export const RefreshButton: React.FC<ButtonProps> = props => {
+  const { t } = useTranslation()
   const dispatch = useDispatch<Dispatch>()
   const { deviceID, fileID, jobID, userId, partnerId } = useParams<{
     deviceID?: string
@@ -42,29 +44,31 @@ export const RefreshButton: React.FC<ButtonProps> = props => {
   const runsPage = useRouteMatch<{ fileID?: string }>('/runs/:fileID?')
   const scriptPage = useRouteMatch('/script')
 
-  let title = 'Refresh application'
+  // The /admin section is deliberately English-only, so its titles below stay
+  // untranslated - see the admin pages, none of which use useTranslation.
+  let title = t('refreshButton.application', 'Refresh application')
   let methods: Methods = []
 
   // connection pages
   if (connectionPage) {
-    title = 'Refresh connections'
+    title = t('refreshButton.connections', 'Refresh connections')
     methods.push(dispatch.connections.fetch)
 
     // network pages
   } else if (networkPage) {
-    title = 'Refresh networks'
+    title = t('refreshButton.networks', 'Refresh networks')
     methods.push(dispatch.networks.fetchAll)
 
     // scripting pages
   } else if (scriptingPage) {
-    title = 'Refresh scripts'
+    title = t('refreshButton.scripts', 'Refresh scripts')
     methods.push(dispatch.files.fetch)
     const runsFileID = runsPage?.params.fileID
     methods.push(async () => await dispatch.jobs.fetch({ fileID: runsFileID }))
 
     // script pages
   } else if (scriptPage) {
-    title = 'Refresh script'
+    title = t('refreshButton.script', 'Refresh script')
     if (fileID) methods.push(async () => await dispatch.files.fetchSingle({ fileId: fileID }))
     if (jobID && jobID.length >= VALID_JOB_ID_LENGTH)
       methods.push(async () => await dispatch.jobs.fetchSingle({ jobId: jobID }))
@@ -72,7 +76,9 @@ export const RefreshButton: React.FC<ButtonProps> = props => {
 
     // log pages
   } else if (logsPage) {
-    title = device ? `Refresh ${device.name} logs` : 'Refresh logs'
+    title = device
+      ? t('refreshButton.deviceLogs', { name: device.name, defaultValue: 'Refresh {{name}} logs' })
+      : t('refreshButton.logs', 'Refresh logs')
     methods.push(async () => {
       if (device) await dispatch.devices.fetchSingleFull({ id: device.id })
       await dispatch.logs.set({ after: undefined, maxDate: undefined })
@@ -81,7 +87,9 @@ export const RefreshButton: React.FC<ButtonProps> = props => {
 
     // device pages
   } else if (devicesPage) {
-    title = device ? `Refresh ${device.name}` : 'Refresh devices'
+    title = device
+      ? t('refreshButton.device', { name: device.name, defaultValue: 'Refresh {{name}}' })
+      : t('refreshButton.devices', 'Refresh devices')
     methods.push(async () => {
       if (device) {
         await dispatch.devices.fetchSingleFull({ id: device.id })
@@ -94,7 +102,7 @@ export const RefreshButton: React.FC<ButtonProps> = props => {
     // add device pages and sub pages - refresh the device list so a newly
     // registered device shows up without leaving the add flow
   } else if (addDevicePage) {
-    title = 'Refresh devices'
+    title = t('refreshButton.devices', 'Refresh devices')
     methods.push(async () => {
       await dispatch.devices.set({ from: 0 })
       await dispatch.devices.fetchList()
@@ -102,17 +110,17 @@ export const RefreshButton: React.FC<ButtonProps> = props => {
 
     // products pages
   } else if (productsPage) {
-    title = 'Refresh products'
+    title = t('refreshButton.products', 'Refresh products')
     methods.push(dispatch.products.fetch)
 
     // account section (any /account/* page) — refresh the connected apps the section owns
   } else if (accountPage) {
-    title = 'Refresh account'
+    title = t('refreshButton.account', 'Refresh account')
     methods.push(dispatch.agents.fetch)
 
     // partner stats pages
   } else if (partnerStatsPage) {
-    title = 'Refresh partner stats'
+    title = t('refreshButton.partnerStats', 'Refresh partner stats')
     methods.push(dispatch.partnerStats.fetch)
 
     // admin users pages

--- a/frontend/src/buttons/RefreshButton/RefreshButton.tsx
+++ b/frontend/src/buttons/RefreshButton/RefreshButton.tsx
@@ -30,6 +30,7 @@ export const RefreshButton: React.FC<ButtonProps> = props => {
   const networkPage = useRouteMatch('/networks')
   const logsPage = useRouteMatch(['/logs', '/devices/:deviceID/logs'])
   const devicesPage = useRouteMatch('/devices')
+  const addDevicePage = useRouteMatch(['/add', '/onboard'])
   const productsPage = useRouteMatch('/products')
   const accountPage = useRouteMatch('/account')
   const partnerStatsPage = useRouteMatch('/partner-stats')
@@ -88,6 +89,15 @@ export const RefreshButton: React.FC<ButtonProps> = props => {
         await dispatch.devices.set({ from: 0 })
         await dispatch.devices.fetchList()
       }
+    })
+
+    // add device pages and sub pages - refresh the device list so a newly
+    // registered device shows up without leaving the add flow
+  } else if (addDevicePage) {
+    title = 'Refresh devices'
+    methods.push(async () => {
+      await dispatch.devices.set({ from: 0 })
+      await dispatch.devices.fetchList()
     })
 
     // products pages

--- a/frontend/src/buttons/RefreshButton/RefreshButton.tsx
+++ b/frontend/src/buttons/RefreshButton/RefreshButton.tsx
@@ -85,8 +85,10 @@ export const RefreshButton: React.FC<ButtonProps> = props => {
       await dispatch.logs.fetch({ deviceId: device?.id })
     })
 
-    // device pages
-  } else if (devicesPage) {
+    // device pages, and the add device pages and sub pages - those carry no
+    // deviceID, so they take the list branch and a newly registered device shows
+    // up without leaving the add flow
+  } else if (devicesPage || addDevicePage) {
     title = device
       ? t('refreshButton.device', { name: device.name, defaultValue: 'Refresh {{name}}' })
       : t('refreshButton.devices', 'Refresh devices')
@@ -97,15 +99,6 @@ export const RefreshButton: React.FC<ButtonProps> = props => {
         await dispatch.devices.set({ from: 0 })
         await dispatch.devices.fetchList()
       }
-    })
-
-    // add device pages and sub pages - refresh the device list so a newly
-    // registered device shows up without leaving the add flow
-  } else if (addDevicePage) {
-    title = t('refreshButton.devices', 'Refresh devices')
-    methods.push(async () => {
-      await dispatch.devices.set({ from: 0 })
-      await dispatch.devices.fetchList()
     })
 
     // products pages

--- a/frontend/src/i18n/locales/de/app.json
+++ b/frontend/src/i18n/locales/de/app.json
@@ -1518,6 +1518,20 @@
     "onboardQuestion": "Haben Sie unser individuelles Pi-Image?",
     "onboardTitle": "Onboarding über Bluetooth"
   },
+  "refreshButton": {
+    "account": "Konto aktualisieren",
+    "application": "Anwendung aktualisieren",
+    "connections": "Verbindungen aktualisieren",
+    "device": "{{name}} aktualisieren",
+    "deviceLogs": "Protokolle von {{name}} aktualisieren",
+    "devices": "Geräte aktualisieren",
+    "logs": "Protokolle aktualisieren",
+    "networks": "Netzwerke aktualisieren",
+    "partnerStats": "Partnerstatistiken aktualisieren",
+    "products": "Produkte aktualisieren",
+    "script": "Skript aktualisieren",
+    "scripts": "Skripte aktualisieren"
+  },
   "rentANodeForm": {
     "addDns": "Öffentliche DNS-Adresse hinzufügen",
     "addIpv6": "Öffentliche IPv6-Adresse hinzufügen",

--- a/frontend/src/i18n/locales/en/app.json
+++ b/frontend/src/i18n/locales/en/app.json
@@ -1564,6 +1564,20 @@
     "onboardQuestion": "Have our custom Pi image?",
     "onboardTitle": "Onboard via Bluetooth"
   },
+  "refreshButton": {
+    "account": "Refresh account",
+    "application": "Refresh application",
+    "connections": "Refresh connections",
+    "device": "Refresh {{name}}",
+    "deviceLogs": "Refresh {{name}} logs",
+    "devices": "Refresh devices",
+    "logs": "Refresh logs",
+    "networks": "Refresh networks",
+    "partnerStats": "Refresh partner stats",
+    "products": "Refresh products",
+    "script": "Refresh script",
+    "scripts": "Refresh scripts"
+  },
   "rentANodeForm": {
     "addDns": "Add a public DNS address",
     "addIpv6": "Add a public IPv6 address",

--- a/frontend/src/i18n/locales/es/app.json
+++ b/frontend/src/i18n/locales/es/app.json
@@ -1540,6 +1540,20 @@
     "onboardQuestion": "¿Tienes nuestra imagen personalizada de Pi?",
     "onboardTitle": "Incorporar mediante Bluetooth"
   },
+  "refreshButton": {
+    "account": "Actualizar cuenta",
+    "application": "Actualizar aplicación",
+    "connections": "Actualizar conexiones",
+    "device": "Actualizar {{name}}",
+    "deviceLogs": "Actualizar registros de {{name}}",
+    "devices": "Actualizar dispositivos",
+    "logs": "Actualizar registros",
+    "networks": "Actualizar redes",
+    "partnerStats": "Actualizar estadísticas de socios",
+    "products": "Actualizar productos",
+    "script": "Actualizar script",
+    "scripts": "Actualizar scripts"
+  },
   "rentANodeForm": {
     "addDns": "Añadir una dirección DNS pública",
     "addIpv6": "Añadir una dirección IPv6 pública",

--- a/frontend/src/i18n/locales/ja/app.json
+++ b/frontend/src/i18n/locales/ja/app.json
@@ -1496,6 +1496,20 @@
     "onboardQuestion": "カスタムPiイメージをお持ちですか?",
     "onboardTitle": "Bluetooth経由でオンボード"
   },
+  "refreshButton": {
+    "account": "アカウントを更新",
+    "application": "アプリケーションを更新",
+    "connections": "コネクトを更新",
+    "device": "{{name}} を更新",
+    "deviceLogs": "{{name}} のログを更新",
+    "devices": "デバイスを更新",
+    "logs": "ログを更新",
+    "networks": "ネットワークを更新",
+    "partnerStats": "パートナー統計を更新",
+    "products": "プロダクトを更新",
+    "script": "スクリプトを更新",
+    "scripts": "スクリプトを更新"
+  },
   "rentANodeForm": {
     "addDns": "公開DNSアドレスを追加",
     "addIpv6": "公開IPv6アドレスを追加",

--- a/frontend/src/models/auth.ts
+++ b/frontend/src/models/auth.ts
@@ -85,7 +85,7 @@ export default createModel<RootModel>()({
     // silent suppresses the session-error toast for machine-triggered runs (a
     // network reconnect), where the user didn't ask for this and may not even be
     // looking at the app. See Controller.onNetworkConnect.
-    async init(options: { silent?: boolean }, state) {
+    async init(options: { silent?: boolean } = {}, state) {
       const { user } = state.auth
       console.log('AUTH INIT START', { user })
       if (!user) {
@@ -94,7 +94,7 @@ export default createModel<RootModel>()({
         console.log('AUTH INIT', { authService })
         await sleep(500)
         await dispatch.auth.set({ authService })
-        await dispatch.auth.checkSession({ refreshToken: true, silent: options?.silent })
+        await dispatch.auth.checkSession({ refreshToken: true, silent: options.silent })
       }
       dispatch.auth.set({ initialized: true })
       console.log('AUTH INIT END')

--- a/frontend/src/models/auth.ts
+++ b/frontend/src/models/auth.ts
@@ -294,7 +294,7 @@ export default createModel<RootModel>()({
       window.location.hash = ''
       zendesk.endChat()
       emit('user/sign-out-complete')
-      cloudController.close()
+      cloudController.reset()
       Controller.close()
     },
     async globalSignOut() {

--- a/frontend/src/models/auth.ts
+++ b/frontend/src/models/auth.ts
@@ -82,7 +82,10 @@ const authServiceConfig = (): ConfigInterface => ({
 export default createModel<RootModel>()({
   state: defaultState,
   effects: dispatch => ({
-    async init(_: void, state) {
+    // silent suppresses the session-error toast for machine-triggered runs (a
+    // network reconnect), where the user didn't ask for this and may not even be
+    // looking at the app. See Controller.onNetworkConnect.
+    async init(options: { silent?: boolean }, state) {
       const { user } = state.auth
       console.log('AUTH INIT START', { user })
       if (!user) {
@@ -91,7 +94,7 @@ export default createModel<RootModel>()({
         console.log('AUTH INIT', { authService })
         await sleep(500)
         await dispatch.auth.set({ authService })
-        await dispatch.auth.checkSession({ refreshToken: true })
+        await dispatch.auth.checkSession({ refreshToken: true, silent: options?.silent })
       }
       dispatch.auth.set({ initialized: true })
       console.log('AUTH INIT END')
@@ -163,15 +166,16 @@ export default createModel<RootModel>()({
       if (!state.auth.authService) return
       await state.auth.authService.forceTokenRefresh()
     },
-    async checkSession(options: { refreshToken: boolean }, state) {
+    async checkSession(options: { refreshToken: boolean; silent?: boolean }, state) {
       if (!state.auth.authService) return
       try {
-        const result = await state.auth.authService.checkSignIn(options)
+        const result = await state.auth.authService.checkSignIn({ refreshToken: options.refreshToken })
         if (result.cognitoUser) {
           await dispatch.auth.handleSignInSuccess(result.cognitoUser)
         } else {
           console.error('SESSION ERROR', result.error, result)
-          if (result.error?.message) dispatch.ui.set({ errorMessage: result.error.message })
+          // still logged above - silent only withholds the user-facing toast
+          if (result.error?.message && !options.silent) dispatch.ui.set({ errorMessage: result.error.message })
         }
       } catch (error) {
         console.error('Check sign in error', error)

--- a/frontend/src/services/CloudSync.ts
+++ b/frontend/src/services/CloudSync.ts
@@ -12,15 +12,19 @@ class CloudSync {
   init() {
     if (this.initialized) return
     this.initialized = true
-    network.on('connect', async () => {
-      await dispatch.devices.expire()
-      this.all()
-    })
+    network.on('connect', this.onNetworkConnect)
   }
 
   reset() {
     this.initialized = false
-    network.off('connect', this.all)
+    network.off('connect', this.onNetworkConnect)
+  }
+
+  // named so reset() can actually remove it — an inline closure left a listener
+  // behind on every sign out, stacking a full sync per sign in cycle
+  onNetworkConnect = async () => {
+    await dispatch.devices.expire()
+    this.all()
   }
 
   async call(methods: Methods, parallel?: boolean, spinner: boolean = true) {

--- a/frontend/src/services/CloudSync.ts
+++ b/frontend/src/services/CloudSync.ts
@@ -12,17 +12,19 @@ class CloudSync {
   init() {
     if (this.initialized) return
     this.initialized = true
-    network.on('connect', this.onNetworkConnect)
+    network.on('active', this.onNetworkActive)
   }
 
   reset() {
     this.initialized = false
-    network.off('connect', this.onNetworkConnect)
+    network.off('active', this.onNetworkActive)
   }
 
-  // named so reset() can actually remove it — an inline closure left a listener
-  // behind on every sign out, stacking a full sync per sign in cycle
-  onNetworkConnect = async () => {
+  // 'active' rather than 'connect' so a full re-sync waits until the window is in
+  // front - sockets reconnect on 'connect' regardless, so nothing is missed.
+  // Named so reset() can actually remove it: an inline closure left a listener
+  // behind on every sign out, stacking a full sync per sign in cycle.
+  onNetworkActive = async () => {
     await dispatch.devices.expire()
     this.all()
   }

--- a/frontend/src/services/Controller.ts
+++ b/frontend/src/services/Controller.ts
@@ -23,9 +23,8 @@ class Controller extends EventEmitter {
     network.on('connect', this.onNetworkConnect)
     // Deliberately no 'disconnect' listener. This socket talks to the backend on
     // 127.0.0.1, which stays reachable when internet access drops - closing it
-    // would blind the UI to local connection state for no reason, and reopening
-    // depends on network's 'connect', which is gated on window focus. Losing the
-    // local backend instead surfaces through socket.io's own reconnection.
+    // would blind the UI to local connection state for no reason. Losing the local
+    // backend is a different failure, and socket.io's own reconnection covers it.
   }
 
   log(...args) {

--- a/frontend/src/services/Controller.ts
+++ b/frontend/src/services/Controller.ts
@@ -36,12 +36,17 @@ class Controller extends EventEmitter {
     const { ui, auth } = store.dispatch
 
     if (!navigator.onLine) return
-    // Signed in is the condition for re-opening, not backendAuthenticated: a
-    // dropped socket clears that flag (auth.disconnect), so keying off it meant
-    // waking from sleep took the auth.init() branch, which no-ops once a user is
-    // in state - the re-connect nudge never actually ran. auth isn't persisted,
-    // so at startup this is still false and initial sign in is unaffected.
-    if (state.auth.authenticated) {
+    // Keyed off the user, not backendAuthenticated or authenticated:
+    //  - backendAuthenticated is cleared by a dropped socket (auth.disconnect), so
+    //    waking from sleep took the auth.init() branch, which no-ops once a user
+    //    is in state - the re-connect nudge never actually ran.
+    //  - authenticated is set before fetchUser, so it stays true when graphQLLogin
+    //    fails, leaving no user and no socket. Reopening nothing would strand that
+    //    sign in until a reload; it needs the auth.init() retry instead.
+    // A user means sign in completed and setupConnection made a socket to reopen.
+    // auth isn't persisted, so this is false at startup and initial sign in still
+    // takes the else branch.
+    if (state.auth.user) {
       this.log('-- ONLINE AUTHORIZED RE-CONNECT')
       this.open()
     } else {

--- a/frontend/src/services/Controller.ts
+++ b/frontend/src/services/Controller.ts
@@ -54,9 +54,9 @@ class Controller extends EventEmitter {
       ui.set({ errorMessage: '' })
       // This is the app's only entry into auth.init, so it has to run whether or
       // not the window has focus - a window launched in the background still has
-      // to sign in. Unfocused, though, nobody asked for this and nobody is
+      // to sign in. Unattended, though, nobody asked for this and nobody is
       // watching, so a failed session check shouldn't leave a toast waiting.
-      auth.init({ silent: !document.hasFocus() })
+      auth.init({ silent: !network.isActive() })
     }
   }
 
@@ -115,6 +115,9 @@ class Controller extends EventEmitter {
     // the offline notice as a side effect.
     if (!browser.hasBackend) return
     if (force || (navigator.onLine && !this.socket?.connected && !this.retrying)) {
+      // force skips the !retrying guard above, so drop any pending retry rather
+      // than orphan its timer - it would fire up to FRONTEND_RETRY_DELAY later
+      clearTimeout(this.retrying)
       this.retrying = setTimeout(
         () => {
           this.log('Retrying local socket.io connection')
@@ -127,8 +130,7 @@ class Controller extends EventEmitter {
     }
   }
 
-  // arrow so `this` survives if it's ever passed as a callback - as an unbound
-  // method an emitter calls it with itself as `this` and it closes nothing
+  // arrow so it stays bound if passed as a callback
   close = () => {
     this.log('CLOSE LOCAL SOCKET')
     this.socket?.close()

--- a/frontend/src/services/Controller.ts
+++ b/frontend/src/services/Controller.ts
@@ -47,7 +47,11 @@ class Controller extends EventEmitter {
     } else {
       this.log('1- ONLINE AUTHORIZE AND CONNECT')
       ui.set({ errorMessage: '' })
-      auth.init()
+      // This is the app's only entry into auth.init, so it has to run whether or
+      // not the window has focus - a window launched in the background still has
+      // to sign in. Unfocused, though, nobody asked for this and nobody is
+      // watching, so a failed session check shouldn't leave a toast waiting.
+      auth.init({ silent: !document.hasFocus() })
     }
   }
 
@@ -101,6 +105,10 @@ class Controller extends EventEmitter {
 
   // Retry open with delay, force skips delay
   open(retry?: boolean, force?: boolean) {
+    // Nothing to open without a local backend (portal/mobile) - setupConnection
+    // never made a socket there, so this would only schedule a timeout to clear
+    // the offline notice as a side effect.
+    if (!browser.hasBackend) return
     if (force || (navigator.onLine && !this.socket?.connected && !this.retrying)) {
       this.retrying = setTimeout(
         () => {

--- a/frontend/src/services/Controller.ts
+++ b/frontend/src/services/Controller.ts
@@ -21,7 +21,11 @@ class Controller extends EventEmitter {
     this.onNetworkConnect()
     if (!navigator.onLine) network.offline()
     network.on('connect', this.onNetworkConnect)
-    network.on('disconnect', this.close)
+    // Deliberately no 'disconnect' listener. This socket talks to the backend on
+    // 127.0.0.1, which stays reachable when internet access drops - closing it
+    // would blind the UI to local connection state for no reason, and reopening
+    // depends on network's 'connect', which is gated on window focus. Losing the
+    // local backend instead surfaces through socket.io's own reconnection.
   }
 
   log(...args) {
@@ -33,7 +37,12 @@ class Controller extends EventEmitter {
     const { ui, auth } = store.dispatch
 
     if (!navigator.onLine) return
-    if (state.auth.backendAuthenticated) {
+    // Signed in is the condition for re-opening, not backendAuthenticated: a
+    // dropped socket clears that flag (auth.disconnect), so keying off it meant
+    // waking from sleep took the auth.init() branch, which no-ops once a user is
+    // in state - the re-connect nudge never actually ran. auth isn't persisted,
+    // so at startup this is still false and initial sign in is unaffected.
+    if (state.auth.authenticated) {
       this.log('-- ONLINE AUTHORIZED RE-CONNECT')
       this.open()
     } else {
@@ -48,6 +57,16 @@ class Controller extends EventEmitter {
     this.handlers = getEventHandlers()
 
     if (!browser.hasBackend) return
+
+    // Re-auth (token refresh, or signing back in) calls this again. Drop the
+    // previous socket first - listeners are removed before closing so its
+    // disconnect handler doesn't fire, and its handlers can't double dispatch
+    // every backend event onto the new connection's.
+    if (this.socket) {
+      this.log('REPLACING LOCAL SOCKET')
+      this.socket.removeAllListeners()
+      this.socket.close()
+    }
 
     this.socket = io(this.url, {
       transports: ['websocket'],
@@ -96,7 +115,9 @@ class Controller extends EventEmitter {
     }
   }
 
-  close() {
+  // arrow so `this` survives if it's ever passed as a callback - as an unbound
+  // method an emitter calls it with itself as `this` and it closes nothing
+  close = () => {
     this.log('CLOSE LOCAL SOCKET')
     this.socket?.close()
   }

--- a/frontend/src/services/Network.ts
+++ b/frontend/src/services/Network.ts
@@ -48,7 +48,6 @@ class Network extends EventEmitter {
   awake = () => {
     this.log('WAKE')
     this.shouldConnect = true
-    this.shouldSync = true
     this.connect()
   }
 
@@ -63,7 +62,6 @@ class Network extends EventEmitter {
       offline: { title: 'Disconnected', message: 'Internet access is required.', severity: 'warning' },
     })
     this.shouldConnect = true
-    this.shouldSync = true
     this.emit('disconnect')
   }
 
@@ -73,20 +71,18 @@ class Network extends EventEmitter {
     dispatch.ui.set({ offline: undefined })
     // the browser only fires this on a transition, so it's the definitive
     // "connectivity restored" signal - don't depend on a matching offline event
-    // having set these, it may have been consumed or missed
+    // having set this, it may have been consumed or missed
     this.shouldConnect = true
-    this.shouldSync = true
     this.connect()
   }
 
   connect = () => {
-    // sockets come back as soon as there is a network, focused or not
     if (this.shouldConnect && navigator.onLine) {
       this.shouldConnect = false
+      this.shouldSync = true // every reconnect owes a sync, paid once in front
       this.log('CONNECT')
       this.emit('connect')
     }
-    // re-syncing everything is expensive, so it waits for the window to be in front
     if (this.shouldSync && this.isActive()) {
       this.shouldSync = false
       this.log('ACTIVE')

--- a/frontend/src/services/Network.ts
+++ b/frontend/src/services/Network.ts
@@ -2,11 +2,19 @@ import { dispatch } from '../store'
 import { EventEmitter } from 'events'
 
 class Network extends EventEmitter {
-  // connect, disconnect, change events are emitted
+  // connect, active, disconnect, change events are emitted
+  //
+  // connect - connectivity is back, so anything holding a socket should re-open it.
+  //   Fires whether or not the window has focus: a backgrounded app that waits for
+  //   focus sits with dead sockets, and the cloud socket in particular has no other
+  //   way back (close() drops its listeners, so it can't self-retry).
+  // active - connectivity is back AND the window has focus. For the expensive work
+  //   (a full cloud sync) that's only worth doing when someone is looking at it.
 
   tickDuration = 60 * 1000 // 1 minute
   sleepDuration = 10 * this.tickDuration // 10 minutes
   shouldConnect: boolean = false
+  shouldSync: boolean = false
   interval?: NodeJS.Timeout
   then = 0
 
@@ -40,6 +48,7 @@ class Network extends EventEmitter {
   awake = () => {
     this.log('WAKE')
     this.shouldConnect = true
+    this.shouldSync = true
     this.connect()
   }
 
@@ -54,6 +63,7 @@ class Network extends EventEmitter {
       offline: { title: 'Disconnected', message: 'Internet access is required.', severity: 'warning' },
     })
     this.shouldConnect = true
+    this.shouldSync = true
     this.emit('disconnect')
   }
 
@@ -61,14 +71,26 @@ class Network extends EventEmitter {
     if (!navigator.onLine) return
     this.log('NETWORK ONLINE')
     dispatch.ui.set({ offline: undefined })
+    // the browser only fires this on a transition, so it's the definitive
+    // "connectivity restored" signal - don't depend on a matching offline event
+    // having set these, it may have been consumed or missed
+    this.shouldConnect = true
+    this.shouldSync = true
     this.connect()
   }
 
   connect = () => {
-    if (this.shouldConnect && this.isActive()) {
+    // sockets come back as soon as there is a network, focused or not
+    if (this.shouldConnect && navigator.onLine) {
       this.shouldConnect = false
       this.log('CONNECT')
       this.emit('connect')
+    }
+    // re-syncing everything is expensive, so it waits for the window to be in front
+    if (this.shouldSync && this.isActive()) {
+      this.shouldSync = false
+      this.log('ACTIVE')
+      this.emit('active')
     }
   }
 

--- a/frontend/src/services/cloudController.ts
+++ b/frontend/src/services/cloudController.ts
@@ -39,6 +39,7 @@ class CloudController {
   init() {
     if (this.initialized) {
       console.warn('CLOUD CONTROLLER ALREADY INITIALIZED')
+      this.connect() // no-op if the socket is still up, recovers it if it was closed
       return
     }
     this.connect()
@@ -74,6 +75,9 @@ class CloudController {
   startPing() {
     if (this.timer) clearInterval(this.timer)
     this.log('START PING', this.pingInterval)
+    // reset the pong clock so a stale timestamp from a previous connection
+    // doesn't make the first ping of this one look unanswered
+    this.pongReceived = Date.now()
     this.timer = setInterval(this.ping, this.pingInterval)
   }
 
@@ -104,6 +108,21 @@ class CloudController {
     this.socket?.removeEventListener('error', this.onError)
     this.socket?.close()
     delete this.socket
+  }
+
+  /**
+   * Tear down for sign out. Unlike close(), which only drops the socket and
+   * expects a network event to bring it back, this clears initialized and the
+   * network listeners so the next signedIn() can init() from scratch.
+   */
+  reset = () => {
+    this.log('RESET')
+    this.close()
+    if (this.timer) clearInterval(this.timer)
+    this.timer = undefined
+    network.off('connect', this.reconnect)
+    network.off('disconnect', this.close)
+    this.initialized = false
   }
 
   onClose = event => this.log('CLOSED', event)

--- a/frontend/src/services/cloudController.ts
+++ b/frontend/src/services/cloudController.ts
@@ -36,13 +36,11 @@ class CloudController {
   pongReceived: number = Date.now()
   timer?: NodeJS.Timeout
 
+  // Idempotent: connect() is a no-op when the socket is up, so a second signedIn()
+  // recovers a closed socket rather than returning early and leaving it dead.
   init() {
-    if (this.initialized) {
-      console.warn('CLOUD CONTROLLER ALREADY INITIALIZED')
-      this.connect() // no-op if the socket is still up, recovers it if it was closed
-      return
-    }
     this.connect()
+    if (this.initialized) return
     network.on('connect', this.reconnect)
     network.on('disconnect', this.close)
     this.initialized = true

--- a/frontend/src/services/cloudController.ts
+++ b/frontend/src/services/cloudController.ts
@@ -136,6 +136,10 @@ class CloudController {
   }
 
   authenticate = async () => {
+    // Capture the socket before awaiting the token: signing out mid-flight replaces
+    // it, and sending this subscribe on the successor would double up its
+    // subscription - every device event would then be processed twice.
+    const socket = this.socket
     const message = JSON.stringify({
       action: 'subscribe',
       // Opt in to bulk-frame delivery on the server. The notify Lambda
@@ -266,7 +270,11 @@ class CloudController {
         }
       }`,
     })
-    this.socket?.send(message)
+    if (socket !== this.socket) {
+      this.log('STALE AUTHENTICATE - SOCKET REPLACED')
+      return
+    }
+    socket?.send(message)
   }
 
   onMessage = response => {


### PR DESCRIPTION
## Cloud websocket never reconnected after signing out and back in

`cloudController.init()` is guarded by an `initialized` flag that `close()` never cleared:

- sign out → `auth.signedOut()` → `cloudController.close()` — socket dropped, `initialized` stays `true`
- sign back in → `auth.signedIn()` → `cloudController.init()` → logs *"CLOUD CONTROLLER ALREADY INITIALIZED"* and returns without connecting

The result was no cloud events at all after re-signing in: no device online/offline state, no session or notification updates. It only self-healed by accident — the ping timer from the *previous* session was never cleared either, so the "no pong received" watchdog fired a reconnect roughly 10–12 minutes later. Nothing reloads the renderer on sign out (checked `AuthService.signOut` and the electron `signOutComplete` handler), so module state really does survive the cycle.

- Added `cloudController.reset()`: closes the socket, clears the ping timer, removes its `network` connect/disconnect listeners, clears `initialized`. `auth.signedOut()` calls it instead of `close()`, so the next `init()` starts clean without stacking duplicate network listeners.
- `init()` now calls `connect()` on the already-initialized path too, so a stray double `signedIn()` recovers the socket rather than leaving it dead.
- `startPing()` resets `pongReceived`, so a stale timestamp from the old connection can't make the first ping of a new one look unanswered.

### CloudSync listener leak (same cycle)

`CloudSync.reset()` called `network.off('connect', this.all)`, but `init()` had registered an inline closure — so the `off` removed nothing and every sign out/in cycle left another listener behind, stacking one extra full cloud sync per cycle on each network reconnect. The handler is now a named property.

## Reconnection waited for window focus

The bigger reliability problem underneath all of this: `Network.connect()` gated its `connect` event on `isActive()`, which is `document.hasFocus() && navigator.onLine`. So when connectivity returned — or the machine woke from sleep — while the app was in the background, no `connect` event fired at all, and everything listening for it stayed down until someone clicked on the window.

That hits the cloud socket hardest. `cloudController.close()` removes its listeners and closes the socket, which kills ReconnectingWebSocket's own retry, so network's `connect` is its *only* way back. A backgrounded desktop app that lost wifi for a moment would sit with a dead cloud socket — no device state, no notifications — until the user focused it, or until the ping watchdog eventually fired ~10 minutes later.

The focus gate wasn't pointless, though: `connect` also drives CloudSync's full re-sync, which is expensive and genuinely not worth doing in the background. So the two concerns are now separate events:

- **`connect`** — connectivity is back. Fires regardless of focus. Sockets re-open immediately (`Controller`, `cloudController`).
- **`active`** — connectivity is back *and* the window has focus. Carries the expensive work (`CloudSync`), so its behavior is unchanged.

`online` also now sets both flags itself rather than depending on a matching `offline` event having set them — the browser only fires it on a transition, so it's the definitive "connectivity restored" signal. The other `connect` listeners are safe to run unfocused: `Heartbeat.start` already self-guards on `network.isActive()`, and zendesk's just shows/hides the chat widget.

## Local (socket.io) backend socket

This one did reconnect on sign in — `fetchUser()` → `setupConnection()` builds a fresh `forceNew` socket — but it never disposed of the old one. `checkSession` can re-run mid-session (a 401/403 in `services/post.ts` triggers exactly that), which left two live sockets with both handler sets attached, double-dispatching every backend event. `setupConnection` now removes listeners and closes any existing socket first.

Two related bugs in `Controller.init`:

- `network.on('disconnect', this.close)` passed an unbound method, so it ran with `this === network` and closed nothing (the tell: it logged in red rather than green). Rather than bind it, the listener is **removed**: this socket talks to the backend on `127.0.0.1`, which stays reachable when internet access drops, so closing it would blind the UI to local connection state for no reason. Losing the local backend is a different failure, and socket.io's own reconnection covers it. `close` is now an arrow function so the unbound-`this` trap can't recur.
- `onNetworkConnect` keyed its re-connect branch off `backendAuthenticated`, which a dropped socket clears (via `auth.disconnect`). So on wake-from-sleep it took the `auth.init()` branch, which no-ops once a user is in state — the re-connect nudge never ran. It now keys off `authenticated`. `auth` isn't in the redux-persist whitelist, so this is still `false` at startup and initial sign in is unaffected.

## Global refresh on the add device pages

`/add`, `/add/:platform`, `/add/raspberrypi-options` and `/onboard/*` matched none of the route branches in `RefreshButton`, so refresh fell through to `cloudSync.core()` only — accounts, user, org, sessions, tags, plans, announcements — and never the device list. Added an `addDevicePage` branch covering `/add` and the `/onboard` sub-flow (which `ROUTE_PARENTS` treats as part of add) that resets pagination and re-fetches the list, matching the `/devices` branch. The button renders globally from the Header, so it's present on all of those pages.

## Testing

`npm run typecheck` passes. The sign out/in path needs real credentials, so it was traced through the code rather than exercised — worth a manual pass:

- Sign out, sign back in → expect `CLOUD SOCKET CONNECT` / `OPENED` in the console, and live device state changes.
- Repeat the cycle a few times → expect exactly one cloud sync per reconnect, not one per cycle.
- Toggle wifi off/on **with the app in the background**, then come back → the sockets should already be up (`CONNECT` in the log at the moment the network returned, `ACTIVE` and the sync only once focused).
- Sleep/wake the machine while signed in → same expectation, driven by the 60s tick rather than the online event.
