### PR TITLE
fix(auth): don't stall sign out when the local socket is disconnected

### DIFF
--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -85,6 +85,9 @@ export const REGEX_SCHEME = /^(.*?):\/\//
 export const DESKTOP_EPOCH = new Date('2020-01-01T00:00:00')
 export const MOBILE_LAUNCH_DATE = new Date('2023-12-20')
 export const FRONTEND_RETRY_DELAY = 20000
+// How long sign out waits for the local backend to come back before giving up and
+// tearing down the frontend on its own. Short: it's a localhost socket.
+export const SIGN_OUT_BACKEND_TIMEOUT = 3000
 export const MAX_CONNECTION_NAME_LENGTH = 62
 export const MAX_DESCRIPTION_LENGTH = 1024
 export const SIDEBAR_WIDTH = 250

--- a/frontend/src/models/auth.ts
+++ b/frontend/src/models/auth.ts
@@ -246,8 +246,13 @@ export default createModel<RootModel>()({
       if (!browser.hasBackend) dispatch.auth.appReady()
     },
     async signOut(_: void, state) {
-      if (state.auth.backendAuthenticated) emit('user/sign-out')
-      else await dispatch.auth.signedOut()
+      // emit returns false when the local socket isn't connected, and
+      // backendAuthenticated can still be true at that moment - the flag is only
+      // cleared once the socket's disconnect event lands. Without checking the
+      // return value, sign out in that window did nothing at all: no purge, no
+      // teardown, no redirect, and the user stayed signed in with no feedback.
+      if (state.auth.backendAuthenticated && emit('user/sign-out')) return
+      await dispatch.auth.signedOut()
     },
     /**
      * Gets called when the backend signs the user out

--- a/frontend/src/models/auth.ts
+++ b/frontend/src/models/auth.ts
@@ -16,6 +16,7 @@ import {
   SIGNOUT_REDIRECT_URL,
   API_URL,
   DEVELOPER_KEY,
+  SIGN_OUT_BACKEND_TIMEOUT,
 } from '../constants'
 import { persistor } from '../store'
 import { graphQLLogin } from '../services/graphQLRequest'
@@ -251,7 +252,17 @@ export default createModel<RootModel>()({
       // cleared once the socket's disconnect event lands. Without checking the
       // return value, sign out in that window did nothing at all: no purge, no
       // teardown, no redirect, and the user stayed signed in with no feedback.
-      if (state.auth.backendAuthenticated && emit('user/sign-out')) return
+      if (state.auth.backendAuthenticated) {
+        if (emit('user/sign-out')) return
+        // Don't tear down behind the backend's back if it's only momentarily
+        // unreachable. It owns cli.signOut() and the connection pool, and a
+        // frontend-only sign out leaves the CLI admin registered - which makes
+        // the helper reject a different account until someone runs a manual
+        // 'remoteit signout'. Force the socket back rather than wait out
+        // socket.io's 20s retry, then send it for real.
+        if ((await Controller.reconnectNow(SIGN_OUT_BACKEND_TIMEOUT)) && emit('user/sign-out')) return
+        console.warn('SIGN OUT: local backend unreachable, signing the app out only')
+      }
       await dispatch.auth.signedOut()
     },
     /**

--- a/frontend/src/services/Controller.ts
+++ b/frontend/src/services/Controller.ts
@@ -131,7 +131,7 @@ class Controller extends EventEmitter {
 
       let timer: NodeJS.Timeout | undefined
       const finish = (result: boolean) => {
-        if (timer) clearTimeout(timer)
+        clearTimeout(timer)
         socket.off('authenticated', onAuthenticated)
         this.log('RECONNECT NOW', result ? 'AUTHENTICATED' : 'TIMED OUT')
         resolve(result)

--- a/frontend/src/services/Controller.ts
+++ b/frontend/src/services/Controller.ts
@@ -120,6 +120,28 @@ class Controller extends EventEmitter {
     this.socket?.emit(event, ...args)
     return true
   }
+
+  // Force an immediate reopen and resolve once the backend has authenticated the
+  // new connection, false if it doesn't come back within timeout. socket.io's own
+  // retry waits FRONTEND_RETRY_DELAY, far too long to hold a sign out on.
+  reconnectNow = (timeout: number): Promise<boolean> =>
+    new Promise(resolve => {
+      const socket = this.socket
+      if (!browser.hasBackend || !socket) return resolve(false)
+
+      let timer: NodeJS.Timeout | undefined
+      const finish = (result: boolean) => {
+        if (timer) clearTimeout(timer)
+        socket.off('authenticated', onAuthenticated)
+        this.log('RECONNECT NOW', result ? 'AUTHENTICATED' : 'TIMED OUT')
+        resolve(result)
+      }
+      const onAuthenticated = () => finish(true)
+
+      socket.on('authenticated', onAuthenticated)
+      timer = setTimeout(() => finish(false), timeout)
+      this.open(false, true)
+    })
 }
 
 type EventHandlers = { [event: string]: (data?: any) => any }


### PR DESCRIPTION
Follow-up from the review of #1165. Independent of that PR — branched off `main`, one file, no overlap.

## Sign out can silently do nothing

`signOut` fires an event at the backend and assumes it lands:

```ts
if (state.auth.backendAuthenticated) emit('user/sign-out')
else await dispatch.auth.signedOut()
```

But `Controller.emit` returns `false` and logs `EMIT CANCELED - LOCAL SOCKET DISCONNECTED` when the socket isn't connected, and the return value is dropped here. The two conditions aren't mutually exclusive: `backendAuthenticated` is only cleared once the socket's `disconnect` event lands and `auth.disconnect` runs. In the window between the socket dropping and that flag being cleared, `signOut` takes the first branch, the emit is cancelled, and **nothing happens at all** — no `persistor.purge()`, no Cognito sign out, no model resets, no redirect. The user clicks Sign Out and stays signed in, with no error.

The fix falls through to the local teardown whenever the emit didn't go out:

```ts
if (state.auth.backendAuthenticated && emit('user/sign-out') 
```

The backend-driven path is unchanged: when the emit succeeds we still return and wait for the backend to send `signed-out`, which drives `auth.signedOut()` as before.

## Why it matters beyond the narrow race

The same fallback also covers the backend being wedged or gone — anything where the socket reports disconnected while the flag says otherwise. Sign out is the one action that should never no-op, since the user may be handing the machine to someone else.

## Testing

`npm run typecheck` passes. Reproducing the race by hand is awkward (it needs the backend to drop in the instant between the click and the flag clearing); the reliable way to exercise the new path is to kill the helper process, then sign out — before this it hangs signed in, after it signs out locally.
