### PR TITLE
fix(scripting): sort selected devices by name when added

### DIFF
--- a/frontend/src/components/DeviceListHeaderCheckbox.tsx
+++ b/frontend/src/components/DeviceListHeaderCheckbox.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { State, Dispatch } from '../store'
 import { Checkbox } from '@mui/material'
-import { sortSelectedIds } from '../helpers/selectionRange'
 import { Icon } from './Icon'
 
 type Props = { select?: boolean; devices: IDevice[] }
@@ -17,7 +16,7 @@ export const DeviceListHeaderCheckbox: React.FC<Props> = ({ select, devices }) =
   const onClick = event => {
     event.stopPropagation()
     if (indeterminate || selected.length === 0) {
-      dispatch.ui.set({ selected: sortSelectedIds(devices.map(d => d.id), devices) })
+      dispatch.ui.set({ selected: devices.map(d => d.id) })
     } else {
       dispatch.ui.set({ selected: [], selectionAnchor: undefined })
     }

--- a/frontend/src/components/DeviceListHeaderCheckbox.tsx
+++ b/frontend/src/components/DeviceListHeaderCheckbox.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { State, Dispatch } from '../store'
 import { Checkbox } from '@mui/material'
+import { sortSelectedIds } from '../helpers/selectionRange'
 import { Icon } from './Icon'
 
 type Props = { select?: boolean; devices: IDevice[] }
@@ -16,7 +17,7 @@ export const DeviceListHeaderCheckbox: React.FC<Props> = ({ select, devices }) =
   const onClick = event => {
     event.stopPropagation()
     if (indeterminate || selected.length === 0) {
-      dispatch.ui.set({ selected: devices.map(d => d.id) })
+      dispatch.ui.set({ selected: sortSelectedIds(devices.map(d => d.id), devices) })
     } else {
       dispatch.ui.set({ selected: [], selectionAnchor: undefined })
     }

--- a/frontend/src/helpers/selectionRange.ts
+++ b/frontend/src/helpers/selectionRange.ts
@@ -24,12 +24,19 @@ export function mergeSelectedIds(selected: string[], idsToAdd: string[]) {
   return [...new Set([...selected, ...idsToAdd])]
 }
 
-// Keeps the selection in name order from the first click, so it never reorders downstream.
+// Reused across comparisons — localeCompare with options builds a new collator on every call.
+const nameCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' })
+
+// Devices are selected in click order, so re-sort by name on each change to keep the
+// selection ordered. Ids with no loaded device sort last rather than interleaving by raw id.
 export function sortSelectedIds(selected: string[], devices: IDevice[]) {
   const names = new Map(devices.map(device => [device.id, device.name]))
-  return [...selected].sort((a, b) =>
-    (names.get(a) || a).localeCompare(names.get(b) || b, undefined, { numeric: true, sensitivity: 'base' })
-  )
+  return [...selected].sort((a, b) => {
+    const nameA = names.get(a)
+    const nameB = names.get(b)
+    if (!nameA || !nameB) return nameA ? -1 : nameB ? 1 : 0
+    return nameCollator.compare(nameA, nameB)
+  })
 }
 
 export function removeSelectedIds(selected: string[], idsToRemove: string[]) {

--- a/frontend/src/helpers/selectionRange.ts
+++ b/frontend/src/helpers/selectionRange.ts
@@ -24,6 +24,14 @@ export function mergeSelectedIds(selected: string[], idsToAdd: string[]) {
   return [...new Set([...selected, ...idsToAdd])]
 }
 
+// Keeps the selection in name order from the first click, so it never reorders downstream.
+export function sortSelectedIds(selected: string[], devices: IDevice[]) {
+  const names = new Map(devices.map(device => [device.id, device.name]))
+  return [...selected].sort((a, b) =>
+    (names.get(a) || a).localeCompare(names.get(b) || b, undefined, { numeric: true, sensitivity: 'base' })
+  )
+}
+
 export function removeSelectedIds(selected: string[], idsToRemove: string[]) {
   const remove = new Set(idsToRemove)
   return selected.filter(id => !remove.has(id))

--- a/frontend/src/helpers/selectionRange.ts
+++ b/frontend/src/helpers/selectionRange.ts
@@ -24,19 +24,12 @@ export function mergeSelectedIds(selected: string[], idsToAdd: string[]) {
   return [...new Set([...selected, ...idsToAdd])]
 }
 
-// Reused across comparisons — localeCompare with options builds a new collator on every call.
-const nameCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' })
-
-// Devices are selected in click order, so re-sort by name on each change to keep the
-// selection ordered. Ids with no loaded device sort last rather than interleaving by raw id.
+// Devices are selected in click order, so re-order on each change to follow the list the user
+// is looking at — which respects whatever sort they've chosen. Ids no longer in the list (a
+// selection outliving a filter change) keep their relative order at the end.
 export function sortSelectedIds(selected: string[], devices: IDevice[]) {
-  const names = new Map(devices.map(device => [device.id, device.name]))
-  return [...selected].sort((a, b) => {
-    const nameA = names.get(a)
-    const nameB = names.get(b)
-    if (!nameA || !nameB) return nameA ? -1 : nameB ? 1 : 0
-    return nameCollator.compare(nameA, nameB)
-  })
+  const order = new Map(devices.map((device, index) => [device.id, index]))
+  return [...selected].sort((a, b) => (order.get(a) ?? Infinity) - (order.get(b) ?? Infinity))
 }
 
 export function removeSelectedIds(selected: string[], idsToRemove: string[]) {

--- a/frontend/src/hooks/useSelect.ts
+++ b/frontend/src/hooks/useSelect.ts
@@ -23,28 +23,13 @@ export const useSelect = ({ deviceId, selectMode }: UseSelectParams) => {
   const handleSelect = (shiftKey?: boolean) => {
     const state = store.getState()
     const selected = state.ui.selected
-    const selectionAnchor = state.ui.selectionAnchor
     const visibleDevices = selectVisibleDevices(state)
-    const nextSelected = [...selected]
     const selectableIds = getSelectableDeviceIds(visibleDevices)
-    const range = shiftKey ? getInclusiveIdRange(selectableIds, selectionAnchor, deviceId) : []
+    const range = shiftKey ? getInclusiveIdRange(selectableIds, state.ui.selectionAnchor, deviceId) : []
+    const ids = range.length ? range : [deviceId]
+    const nextSelected = isSelected ? removeSelectedIds(selected, ids) : mergeSelectedIds(selected, ids)
 
-    if (range.length) {
-      const rangeSelected = isSelected ? removeSelectedIds(nextSelected, range) : mergeSelectedIds(nextSelected, range)
-      dispatch.ui.set({ selected: sortSelectedIds(rangeSelected, visibleDevices) })
-      dispatch.ui.set({ selectionAnchor: deviceId })
-      return
-    }
-
-    if (isSelected) {
-      const index = nextSelected.indexOf(deviceId)
-      nextSelected.splice(index, 1)
-    } else {
-      nextSelected.push(deviceId)
-    }
-
-    dispatch.ui.set({ selected: sortSelectedIds(nextSelected, visibleDevices) })
-    dispatch.ui.set({ selectionAnchor: deviceId })
+    dispatch.ui.set({ selected: sortSelectedIds(nextSelected, visibleDevices), selectionAnchor: deviceId })
   }
 
   return { isSelected, isAnchorRow, handleSelect }

--- a/frontend/src/hooks/useSelect.ts
+++ b/frontend/src/hooks/useSelect.ts
@@ -1,7 +1,13 @@
 import { useDispatch, useSelector, useStore } from 'react-redux'
 import { Dispatch, State } from '../store'
 import { selectVisibleDevices } from '../selectors/devices'
-import { getInclusiveIdRange, getSelectableDeviceIds, mergeSelectedIds, removeSelectedIds } from '../helpers/selectionRange'
+import {
+  getInclusiveIdRange,
+  getSelectableDeviceIds,
+  mergeSelectedIds,
+  removeSelectedIds,
+  sortSelectedIds,
+} from '../helpers/selectionRange'
 
 type UseSelectParams = {
   deviceId: string
@@ -25,7 +31,7 @@ export const useSelect = ({ deviceId, selectMode }: UseSelectParams) => {
 
     if (range.length) {
       const rangeSelected = isSelected ? removeSelectedIds(nextSelected, range) : mergeSelectedIds(nextSelected, range)
-      dispatch.ui.set({ selected: rangeSelected })
+      dispatch.ui.set({ selected: sortSelectedIds(rangeSelected, visibleDevices) })
       dispatch.ui.set({ selectionAnchor: deviceId })
       return
     }
@@ -37,7 +43,7 @@ export const useSelect = ({ deviceId, selectMode }: UseSelectParams) => {
       nextSelected.push(deviceId)
     }
 
-    dispatch.ui.set({ selected: nextSelected })
+    dispatch.ui.set({ selected: sortSelectedIds(nextSelected, visibleDevices) })
     dispatch.ui.set({ selectionAnchor: deviceId })
   }
 


### PR DESCRIPTION
Devices selected for a script run were kept in click order (or, for select-all, whatever sort the device list happened to be using). That order carried straight through to the created job, so the **Targets** chips and the **Devices** list on the job detail page came out unsorted.

Sorting once at selection time means the order is right from the first click and nothing has to re-sort later — the run form chips, the submitted `deviceIds`, and the resulting job all inherit it.

## Changes

- `sortSelectedIds(selected, devices)` added to `helpers/selectionRange.ts`, alongside the existing `mergeSelectedIds`/`removeSelectedIds`. Uses `localeCompare` with `numeric: true` so `dozer-2` sorts ahead of `dozer-10`.
- Applied at the two places the device list writes to `ui.selected`: `useSelect` (click and shift-range) and `DeviceListHeaderCheckbox` (select-all).

`DeviceScriptingMenu` sets a single id, so it needs no sort. Nothing in the job fetch or socket-update path was touched — existing jobs render exactly as before.

## Notes

- `ui.selected` is shared with the other bulk device actions (tagging, transfer, delete), so those selections are name-ordered now too.
- Names resolve from the visible device list; a selected device filtered out of view falls back to sorting on its raw id. Only reachable by changing the filter mid-selection.

## Testing

- `tsc --noEmit` passes.
- Not exercised in the running app — worth a quick manual check that the created job's device order comes back sorted, in case the API re-orders `jobDevices` on its own.