### PR TITLE
fix(sync): don't fetch files twice on every cloud sync

### DIFF
--- a/frontend/src/services/CloudSync.ts
+++ b/frontend/src/services/CloudSync.ts
@@ -72,7 +72,6 @@ class CloudSync {
       dispatch.devices.fetchList,
       dispatch.networks.fetch,
       dispatch.connections.fetch,
-      dispatch.files.fetch,
       dispatch.products.fetch,
       dispatch.partnerStats.fetch,
     ])


### PR DESCRIPTION
Spotted while reviewing #1165. Independent of it — branched off `main`, one line.

## Every full cloud sync fetched the files list twice

`CloudSync.all()` listed `dispatch.files.fetch` twice in the same `call([...])` array:

```ts
await this.call([
  dispatch.files.fetch,
  dispatch.jobs.fetch,
  dispatch.devices.fetchList,
  dispatch.networks.fetch,
  dispatch.connections.fetch,
  dispatch.files.fetch,   // <- same call again
  dispatch.products.fetch,
  dispatch.partnerStats.fetch,
])
```

`call()` is invoked here without the `parallel` flag, so it runs the array **sequentially** — this isn't a wasted parallel request, it's a second round-trip serialised into the middle of the sync, so it costs latency on top of bandwidth. `all()` runs on every sign-in and on every network reconnect.

The second call is genuinely redundant, not a refresh-after-mutation: `files.fetch` resolves its account via `selectActiveAccountId` when called with no argument, and nothing between the two entries (`jobs`, `devices`, `networks`, `connections`) touches `accounts.activeId`, so the second call re-issues the identical query and overwrites the same state.

`git blame` shows how it happened — the lower entry dates from 0fd567e5 (2024-09-24) and the top one was added later in ac44e2e3 (2024-10-09), which put `files.fetch` at the head of the list without noticing the existing entry further down.

Removed the later one, keeping `files.fetch` first so it still resolves before `jobs.fetch` (jobs reference files), which is the ordering the newer commit intended.

## Testing

`npm run typecheck` passes. Worth a quick manual confirmation: sign in with the network tab open and check the `graphQLFiles` query fires once per sync rather than twice.
