### PR TITLE
fix(scripting): derive run device order from the device list instead of storing it

### DIFF
--- a/frontend/src/helpers/selectionRange.ts
+++ b/frontend/src/helpers/selectionRange.ts
@@ -24,14 +24,6 @@ export function mergeSelectedIds(selected: string[], idsToAdd: string[]) {
   return [...new Set([...selected, ...idsToAdd])]
 }
 
-// Devices are selected in click order, so re-order on each change to follow the list the user
-// is looking at — which respects whatever sort they've chosen. Ids no longer in the list (a
-// selection outliving a filter change) keep their relative order at the end.
-export function sortSelectedIds(selected: string[], devices: IDevice[]) {
-  const order = new Map(devices.map((device, index) => [device.id, index]))
-  return [...selected].sort((a, b) => (order.get(a) ?? Infinity) - (order.get(b) ?? Infinity))
-}
-
 export function removeSelectedIds(selected: string[], idsToRemove: string[]) {
   const remove = new Set(idsToRemove)
   return selected.filter(id => !remove.has(id))

--- a/frontend/src/hooks/useSelect.ts
+++ b/frontend/src/hooks/useSelect.ts
@@ -6,7 +6,6 @@ import {
   getSelectableDeviceIds,
   mergeSelectedIds,
   removeSelectedIds,
-  sortSelectedIds,
 } from '../helpers/selectionRange'
 
 type UseSelectParams = {
@@ -29,7 +28,7 @@ export const useSelect = ({ deviceId, selectMode }: UseSelectParams) => {
     const ids = range.length ? range : [deviceId]
     const nextSelected = isSelected ? removeSelectedIds(selected, ids) : mergeSelectedIds(selected, ids)
 
-    dispatch.ui.set({ selected: sortSelectedIds(nextSelected, visibleDevices), selectionAnchor: deviceId })
+    dispatch.ui.set({ selected: nextSelected, selectionAnchor: deviceId })
   }
 
   return { isSelected, isAnchorRow, handleSelect }

--- a/frontend/src/models/jobs.ts
+++ b/frontend/src/models/jobs.ts
@@ -134,26 +134,6 @@ export default createModel<RootModel>()({
       console.log('STARTED JOB', { result, jobId })
       dispatch.ui.set({ redirect: `/script/${fileId}/latest` })
     },
-    async runAgain(script: IScript) {
-      const deviceIds = script?.job?.jobDevices.map(d => d.device.id) || []
-      const tagValues = script?.job?.tag?.values || []
-      // Convert job arguments to argument values format
-      const argumentValues: IArgumentValue[] = script?.job?.arguments?.map(arg => ({
-        name: arg.name,
-        value: arg.value || '',
-      })) || []
-      await dispatch.jobs.saveRun({
-        deviceIds,
-        jobId: script.job?.id || '',
-        fileId: script.id,
-        name: script.name || '',
-        description: script.shortDesc || '',
-        executable: script.executable,
-        tag: script.job?.tag,
-        access: tagValues.length ? 'TAG' : deviceIds.length ? 'CUSTOM' : 'NONE',
-        argumentValues,
-      })
-    },
     async downloadLogs({ jobId, jobDeviceId }: { jobId: string; jobDeviceId: string }) {
       const result = await getJobLogs(jobId)
       if (result.kind === 'error') {

--- a/frontend/src/pages/ScriptRunPage.tsx
+++ b/frontend/src/pages/ScriptRunPage.tsx
@@ -155,14 +155,19 @@ export const ScriptRunPage: React.FC<Props> = ({ isNew }) => {
     return lookup
   }, [script?.job?.jobDevices])
 
-  // Resolve device names for the current run form
+  // Resolve device names for the current run form, ordered by the device list so the run
+  // follows whatever sort the user has chosen. Derived rather than stored, so changing the
+  // sort after selecting reorders these too. Devices no longer in the list go last.
   const resolvedDevices: { id: string; name: string }[] = useMemo(() => {
     const ids = runForm.access === 'SELECTED' ? selectedIds : runForm.access === 'CUSTOM' ? runForm.deviceIds : []
-    return ids.map(id => {
-      if (jobDeviceNames[id]) return { id, name: jobDeviceNames[id] }
-      const device = devices.find(d => d.id === id) || allDevices.find(d => d.id === id)
-      return { id, name: device?.name || id.slice(0, 8) + '…' }
-    })
+    const order = new Map(devices.map((device, index) => [device.id, index]))
+    return ids
+      .map(id => {
+        if (jobDeviceNames[id]) return { id, name: jobDeviceNames[id] }
+        const device = devices.find(d => d.id === id) || allDevices.find(d => d.id === id)
+        return { id, name: device?.name || id.slice(0, 8) + '…' }
+      })
+      .sort((a, b) => (order.get(a.id) ?? Infinity) - (order.get(b.id) ?? Infinity))
   }, [runForm.access, runForm.deviceIds, selectedIds, jobDeviceNames, devices, allDevices])
 
   const uploadScript = async (): Promise<string | undefined> => {
@@ -175,7 +180,7 @@ export const ScriptRunPage: React.FC<Props> = ({ isNew }) => {
   const handleRun = async () => {
     setRunning(true)
     const form = { ...runForm }
-    if (runForm.access === 'SELECTED') form.deviceIds = selectedIds
+    if (runForm.access === 'SELECTED' || runForm.access === 'CUSTOM') form.deviceIds = resolvedDevices.map(d => d.id)
     if (isNew) {
       const newFileId = await uploadScript()
       if (newFileId) { form.fileId = newFileId; await dispatch.jobs.saveRun(form) }
@@ -190,7 +195,7 @@ export const ScriptRunPage: React.FC<Props> = ({ isNew }) => {
   const handlePrepare = async () => {
     setRunning(true)
     const form = { ...runForm }
-    if (runForm.access === 'SELECTED') form.deviceIds = selectedIds
+    if (runForm.access === 'SELECTED' || runForm.access === 'CUSTOM') form.deviceIds = resolvedDevices.map(d => d.id)
     if (isNew) {
       const newFileId = await uploadScript()
       if (newFileId) { form.fileId = newFileId; await dispatch.jobs.save(form) }


### PR DESCRIPTION
Follow-up to #1167, addressing the Codex review finding on #1169.

#1167 ordered `ui.selected` by device-list position at selection time and stored that order. Codex correctly flagged that the order goes stale: changing the sort in `FilterDrawer` calls `devices.set({ sort })` + `fetchList()`, which reorders the list without any selection click, so `sortSelectedIds` never re-runs. The run form then displays — and submits — the old order.

List position is mutable, so any stored copy of it can drift. The same applies to filtering, searching, and paging, not just sorting. Deriving the order at the point of display removes the whole class of staleness.

## Changes

- `ScriptRunPage.resolvedDevices` now orders by device-list index. It's already a `useMemo` over `devices`, so it recomputes when the list reorders — no extra work, and it covers `SELECTED` and `CUSTOM` alike.
- `handleRun`/`handlePrepare` submit `resolvedDevices.map(d => d.id)`, so what's displayed is what's sent. `CUSTOM` runs are now ordered too, where before only `SELECTED` was touched.
- `sortSelectedIds` is deleted from `helpers/selectionRange.ts` and `useSelect` no longer calls it, so `ui.selected` goes back to plain click order.

Net effect: 14 insertions, 18 deletions — this removes more than it adds.

## Notes

- The `useSelect` simplification from #1167 (collapsed duplicate branches, single dispatch) stays; only the sort call is removed.
- Reverting `ui.selected` to click order also undoes #1167's side effect on the other bulk device actions (tagging, transfer, delete), which never wanted an imposed order.
- Devices not in the current list — a selection outliving a filter change — sort last and keep their relative order.

## Testing

`tsc --noEmit` passes. Not exercised in the running app. The case worth clicking through is the one Codex described: select several devices, change the device list sort, then open the run form and confirm the chips follow the new sort.