### PR TITLE
feat(platforms): add Teltonika to the add device menu

### DIFF
--- a/frontend/src/pages/AddPage.tsx
+++ b/frontend/src/pages/AddPage.tsx
@@ -143,6 +143,7 @@ export const AddPage: React.FC = () => {
             'axis',
             'advantech',
             'idy',
+            'teltonika',
             'ubuntu',
             'windows',
             'mac',

--- a/frontend/src/platforms/teltonika/index.tsx
+++ b/frontend/src/platforms/teltonika/index.tsx
@@ -19,4 +19,9 @@ platforms.register({
   name: 'Teltonika',
   component: Component,
   types: { 1281: 'Teltonika' },
+  installation: {
+    command: true,
+    qualifier: 'For Teltonika routers and gateways',
+    link: 'https://link.remote.it/support/streamline-install',
+  },
 })


### PR DESCRIPTION
### Changes

Requested by @yusuke in Slack: add Teltonika to the **Add a device** menu and to the **Platform** list under Products.

Teltonika (type `1281`) was already registered as a platform in #1142 — icon, name, and type mapping — but it was never offered anywhere in the UI.

- **`frontend/src/pages/AddPage.tsx`** — added `teltonika` to the "Add a device" list, positioned after IDY with the other OEM gateways.
- **`frontend/src/platforms/teltonika/index.tsx`** — added the standard streamline `installation` config. Without it, `/add/teltonika` would render `AddDownload` with no link (a dead button) instead of `AddDevice`. With `command: true`, `useAutoRegistration` sends `platform: 1281` and the API generates the registration command — the same setup Advantech and AXIS use.

**Platform list under Products:** no frontend change needed. That dropdown is driven by the API's `platformTypes.visible` flag, and Evan has already handled the DB update — `1281` now returns `name: "Teltonika"` (Titlecase) with `visible: true`, so it appears in the list with the correct label and picks up the existing platform icon automatically.

TOA (`1228`) is a private, dedicated package and is intentionally left out, per the request.

### Verification

- `npm run typecheck` passes — the only output is the pre-existing `tsconfig` TS5101 deprecations on `baseUrl` / `downlevelIteration`, which are unrelated to this change and present on `main`.
- Confirmed against the API that `platformTypes` returns `1281 / "Teltonika" / visible: true`.
- Not yet exercised end to end: actually creating a product on platform `1281` and running the generated registration command on a real Teltonika device. Worth a manual pass before release.

---
_Generated by [Claude Code](https://claude.ai/code/session_018YfRBMvuTVpXniu6MNi5jo)_